### PR TITLE
fix: 縦書き中間flushで最終列を保留してIssue #51を解消

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -231,7 +231,8 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
 }
 
 void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fontId, const uint16_t columnHeight,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processColumn) {
+                                       const std::function<void(std::shared_ptr<TextBlock>)>& processColumn,
+                                       const bool includeLastColumn) {
   if (words.empty()) return;
 
   // Ensure SD card font metrics are loaded
@@ -294,12 +295,56 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
     verticalIndent = cjkCharAdvance > 0 ? cjkCharAdvance : lineHeight;
   }
 
-  // Break into columns when cumulative height exceeds columnHeight
-  size_t columnStart = 0;
-  int currentY = verticalIndent;
-  bool isFirstColumn = true;
+  // Helper: get the first codepoint of a word string
+  auto firstCodepoint = [](const std::string& w) -> uint32_t {
+    const auto* p = reinterpret_cast<const unsigned char*>(w.c_str());
+    return utf8NextCodepoint(&p);
+  };
 
-  auto emitColumn = [&](size_t start, size_t end) {
+  // First pass: compute column boundaries without emitting.
+  // columnEnds[i] is the exclusive end index of column i (= start of column i+1).
+  std::vector<size_t> columnEnds;
+  {
+    size_t columnStart = 0;
+    int currentY = verticalIndent;
+    for (size_t i = 0; i < words.size(); i++) {
+      if (currentY + wordHeights[i] > columnHeight && i > columnStart) {
+        size_t breakAt = i;
+        // Kinsoku-head pullback (e.g., closing brackets, small kana cannot start a column)
+        while (breakAt > columnStart + 1 && VerticalTextUtils::isKinsokuHead(firstCodepoint(words[breakAt]))) {
+          breakAt--;
+        }
+        // Kinsoku-tail pullback (e.g., opening brackets cannot end a column)
+        if (breakAt > columnStart + 1 && VerticalTextUtils::isKinsokuTail(firstCodepoint(words[breakAt - 1]))) {
+          breakAt--;
+        }
+        columnEnds.push_back(breakAt);
+        columnStart = breakAt;
+        currentY = 0;
+        for (size_t j = columnStart; j <= i; j++) {
+          currentY += wordHeights[j];
+        }
+        continue;
+      }
+      currentY += wordHeights[i];
+    }
+    if (columnStart < words.size()) {
+      columnEnds.push_back(words.size());
+    }
+  }
+
+  // Determine how many columns to emit. Mid-block flushes pass includeLastColumn=false
+  // so the trailing partial column is preserved for the next layout call (avoids visually
+  // short columns at flush boundaries). makePages calls use the default true to flush all.
+  const size_t totalCols = columnEnds.size();
+  const size_t emitCols = (includeLastColumn || totalCols <= 1) ? totalCols : totalCols - 1;
+
+  // Second pass: emit columns up to emitCols.
+  bool isFirstColumn = true;
+  size_t emitStart = 0;
+  for (size_t i = 0; i < emitCols; i++) {
+    const size_t start = emitStart;
+    const size_t end = columnEnds[i];
     std::vector<std::string> colWords(std::make_move_iterator(words.begin() + start),
                                       std::make_move_iterator(words.begin() + end));
     std::vector<int16_t> colYpos;
@@ -324,54 +369,24 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
     processColumn(std::make_shared<TextBlock>(std::move(colWords), std::move(colXpos), std::move(colStyles), blockStyle,
                                               std::move(colYpos), true, std::move(colRubyTexts)));
     isFirstColumn = false;
-  };
+    emitStart = end;
+  }
 
-  // Helper: get the first codepoint of a word string
-  auto firstCodepoint = [](const std::string& w) -> uint32_t {
-    const auto* p = reinterpret_cast<const unsigned char*>(w.c_str());
-    return utf8NextCodepoint(&p);
-  };
-
-  for (size_t i = 0; i < words.size(); i++) {
-    if (currentY + wordHeights[i] > columnHeight && i > columnStart) {
-      // Kinsoku: adjust break point to avoid prohibited line-head/line-tail characters
-      size_t breakAt = i;
-
-      // Check if word at breakAt would start with a kinsoku-head character
-      // If so, pull it back (include it in the current column instead)
-      while (breakAt > columnStart + 1 && VerticalTextUtils::isKinsokuHead(firstCodepoint(words[breakAt]))) {
-        breakAt--;
-      }
-
-      // Check if the last word in the current column is a kinsoku-tail character
-      // If so, pull it to the next column
-      if (breakAt > columnStart + 1 && VerticalTextUtils::isKinsokuTail(firstCodepoint(words[breakAt - 1]))) {
-        breakAt--;
-      }
-
-      emitColumn(columnStart, breakAt);
-      columnStart = breakAt;
-      // Recalculate currentY for the new column
-      currentY = 0;
-      for (size_t j = columnStart; j <= i; j++) {
-        currentY += wordHeights[j];
-      }
-      continue;
+  // Erase only consumed words. Words from emitStart onwards remain in the TextBlock
+  // for the next layout call to render together with newly accumulated text.
+  if (emitStart > 0) {
+    words.erase(words.begin(), words.begin() + emitStart);
+    wordStyles.erase(wordStyles.begin(), wordStyles.begin() + emitStart);
+    wordContinues.erase(wordContinues.begin(), wordContinues.begin() + emitStart);
+    if (!wordVerticalBehaviors.empty()) {
+      const size_t vbConsumed = std::min(emitStart, wordVerticalBehaviors.size());
+      wordVerticalBehaviors.erase(wordVerticalBehaviors.begin(), wordVerticalBehaviors.begin() + vbConsumed);
     }
-    currentY += wordHeights[i];
+    if (!rubyTexts.empty()) {
+      const size_t rtConsumed = std::min(emitStart, rubyTexts.size());
+      rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + rtConsumed);
+    }
   }
-
-  // Emit remaining words as final column
-  if (columnStart < words.size()) {
-    emitColumn(columnStart, words.size());
-  }
-
-  // Consume all data (same pattern as layoutAndExtractLines)
-  words.clear();
-  wordStyles.clear();
-  wordContinues.clear();
-  wordVerticalBehaviors.clear();
-  rubyTexts.clear();
 }
 
 std::vector<uint16_t> ParsedText::calculateWordWidths(const GfxRenderer& renderer, const int fontId) {

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -58,5 +58,6 @@ class ParsedText {
                              const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
                              bool includeLastLine = true);
   void layoutVerticalColumns(const GfxRenderer& renderer, int fontId, uint16_t columnHeight,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processColumn);
+                             const std::function<void(std::shared_ptr<TextBlock>)>& processColumn,
+                             bool includeLastColumn = true);
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -989,9 +989,13 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   if (normalFlush || earlyFlush) {
     LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
     if (self->verticalMode) {
+      // Mid-block flush: keep the trailing partial column so that newly accumulated
+      // text continues into the same column on the next call. Without this, the partial
+      // last column would be emitted prematurely, creating visually short columns at
+      // ruby tag / chunk boundaries (Issue #51).
       self->currentTextBlock->layoutVerticalColumns(
           self->renderer, self->fontId, self->viewportHeight,
-          [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); });
+          [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
     } else {
       const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
       const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)


### PR DESCRIPTION
## Summary

Issue #51 (縦書き書籍で違和感のある位置で改行される) の修正案。

## 真因

`ChapterHtmlSlimParser::characterData` が `wordCount > 750` で `layoutVerticalColumns` を強制呼び出し (中間 flush) するが、`layoutVerticalColumns` は累積した全 words を列として emit してしまうため、**partial な末尾列が flush 境界で生成され、視覚的に明らかに短い列**となっていた。

`<ruby>` タグなど chunk 境界が flush タイミングと重なるケースで頻発する。

### 既存実装の非対称性

horizontal mode の `layoutAndExtractLines` には `includeLastLine` パラメータが既にあり、中間 flush 時に `false` を渡すことで最終行を保留して次の layout に継続させている (line 1002 付近)。一方 vertical mode には同等の機構が無かった。

## 修正内容

| ファイル | 変更 |
|---|---|
| `ParsedText.h` | `layoutVerticalColumns` に `bool includeLastColumn = true` パラメータ追加 |
| `ParsedText.cpp` | 関数を 2-pass refactor: 1) 列境界を計算、2) `includeLastColumn` に応じて emit。emit しなかった words は erase せず保留 |
| `ChapterHtmlSlimParser.cpp` | 中間 flush 経路 (line 992 付近) で `false` を渡す。`makePages` 経路はデフォルト `true` のまま |

## 検証

- 観測された短い列の終端文字列とソースの 750-word flush 境界をシミュレートしたところ、3 ケースで完全一致:
  - 「一命すてて創った」(offset 7475 / 終端 7483)
  - 「さかなは、」(offset 9437 / 終端 9442)  
  - 「谷間を」(offset 8543 終端)
- 残り 2 ケース (Case 1: ちょっと\|躊躇, Case 3: 七年にもな\|る) は粗いシミュレータでは flush 境界に乗らないが、メカニズムは同じ (動的メモリ依存の earlyFlush 100-word 等で説明可能と推測)

## ビルド

- `pio run -e default`: SUCCESS
- RAM: 31.9% / Flash: 89.2% (master とほぼ同等)
- フラッシュ済み (実機検証中)

## Test plan

- [ ] サンプル EPUB「姥捨」を読み込んで縦書きで該当箇所を確認:
  - [ ] Case 1: 「ちょっと躊躇して」 が短い列を作らず連続表示される
  - [ ] Case 2: 「一命すてて創った屍臭ふんぷん」 が連続表示される
  - [ ] Case 3: 「七年にもなるけれど」 が連続表示される
  - [ ] 「さかなは、鑵詰の蟹」 が連続表示される
- [ ] 他の EPUB で縦書き表示の動作が破壊されていない (横書きにも影響なし)
- [ ] 長い章でメモリ枯渇しない (中間 flush 自体は引き続き動作)

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)