### PR TITLE
feat: リリースノートにマージPR一覧を自動追記

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
             firmware.bin
             bootloader.bin
             partitions.bin
+          # body はヘッダーとして使われ、generate_release_notes が有効な場合は
+          # その下に GitHub が自動生成する変更点 (マージされた PR の一覧 / 新規 contributor /
+          # Full Changelog リンク) が追記される。
           body: |
             ## CrossPoint Reader JP ${{ github.ref_name }}
 
@@ -83,6 +86,7 @@ jobs:
 
             1. USB-C でデバイスをPCに接続
             2. `firmware.bin` をダウンロードし、フラッシュツールで書き込み
+          generate_release_notes: true
           prerelease: ${{ contains(github.ref, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub Release のリリースノートに、前回リリース以降にマージされた PR 一覧を自動追記する。

## 現状

`.github/workflows/release.yml` でタグ push 時にリリースを作成しているが、`body` が固定文字列のみで、マージされた PR の一覧やコントリビューター情報が含まれていなかった。

## 変更内容

`softprops/action-gh-release` の `generate_release_notes: true` を有効化。

このフラグにより、既存の `body` (ファームウェア概要・インストール手順) は**ヘッダー**として保持され、その下に GitHub が自動生成する以下の情報が**追記**される:

- 前回リリース以降にマージされた Pull Request の一覧 (タイトルと作者付き)
- 新規 contributor の紹介
- Full Changelog の比較リンク (前タグとの diff)

## 効果

- PR が Conventional Commits 形式 (\`feat:\` / \`fix:\` / \`docs:\` 等) のタイトルだと自動的にカテゴリ分けされる
- 既に Title Check ワークフローでタイトル形式が強制されているため、追加設定は不要
- タグ push のみで完結 (workflow 変更以外、運用フローは変わらない)

## Test plan

- [ ] このPRマージ後、テスト用のタグを切ってリリースが作成されることを確認
- [ ] リリースノートに以下が含まれることを目視確認:
  - [ ] 既存のファームウェア説明
  - [ ] \`What's Changed\` セクションに PR 一覧
  - [ ] \`Full Changelog\` リンク
- [ ] prerelease タグ (例: \`v1.0.0-rc1\`) でも同様に動作

## 参考

- [softprops/action-gh-release: generate_release_notes](https://github.com/softprops/action-gh-release#-customizing)
- [GitHub: Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)