### PR TITLE
feat: ホーム画面の最近の本にも読書状態アイコンを表示

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -15,6 +15,7 @@
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "MappedInputManager.h"
+#include "ReadingStatusHelper.h"
 #include "RecentBooksStore.h"
 #include "activities/settings/AozoraActivity.h"
 #include "components/UITheme.h"
@@ -33,8 +34,10 @@ int HomeActivity::getMenuItemCount() const {
 
 void HomeActivity::loadRecentBooks(int maxBooks) {
   recentBooks.clear();
+  recentBookStatuses.clear();
   const auto& books = RECENT_BOOKS.getBooks();
   recentBooks.reserve(std::min(static_cast<int>(books.size()), maxBooks));
+  recentBookStatuses.reserve(std::min(static_cast<int>(books.size()), maxBooks));
 
   for (const RecentBook& book : books) {
     // Limit to maximum number of recent books
@@ -48,6 +51,7 @@ void HomeActivity::loadRecentBooks(int maxBooks) {
     }
 
     recentBooks.push_back(book);
+    recentBookStatuses.push_back(getReadingStatus(book.path, "/.crosspoint"));
   }
 }
 
@@ -225,8 +229,8 @@ void HomeActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.homeTopPadding}, nullptr);
 
   GUI.drawRecentBookCover(renderer, Rect{0, metrics.homeTopPadding, pageWidth, metrics.homeCoverTileHeight},
-                          recentBooks, selectorIndex, coverRendered, coverBufferStored, bufferRestored,
-                          std::bind(&HomeActivity::storeCoverBuffer, this));
+                          recentBooks, recentBookStatuses, selectorIndex, coverRendered, coverBufferStored,
+                          bufferRestored, std::bind(&HomeActivity::storeCoverBuffer, this));
 
   // Build menu items dynamically
   std::vector<const char*> menuItems = {tr(STR_BROWSE_FILES), tr(STR_MENU_RECENT_BOOKS), tr(STR_FILE_TRANSFER),

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -4,6 +4,7 @@
 
 #include "../Activity.h"
 #include "./FileBrowserActivity.h"
+#include "ReadingStatusHelper.h"
 #include "util/ButtonNavigator.h"
 
 struct RecentBook;
@@ -20,6 +21,7 @@ class HomeActivity final : public Activity {
   bool coverBufferStored = false;  // Track if cover buffer is stored
   uint8_t* coverBuffer = nullptr;  // HomeActivity's own buffer for cover image
   std::vector<RecentBook> recentBooks;
+  std::vector<ReadingStatus> recentBookStatuses;
   void onSelectBook(const std::string& path);
   void onFileBrowserOpen();
   void onRecentsOpen();

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -393,8 +393,10 @@ void BaseTheme::drawTabBar(const GfxRenderer& renderer, const Rect rect, const s
 // Draw the "Recent Book" cover card on the home screen
 // TODO: Refactor method to make it cleaner, split into smaller methods
 void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                                    const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                    bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                    const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex,
+                                    bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                                    std::function<bool()> storeCoverBuffer) const {
+  (void)bookStatuses;
   const bool hasContinueReading = !recentBooks.empty();
   const bool bookSelected = hasContinueReading && selectorIndex == 0;
 

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "ReadingStatusHelper.h"
+
 class GfxRenderer;
 struct RecentBook;
 
@@ -143,8 +145,9 @@ class BaseTheme {
   virtual void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,
                           bool selected) const;
   virtual void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                                   const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                   bool& bufferRestored, std::function<bool()> storeCoverBuffer) const;
+                                   const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex,
+                                   bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                                   std::function<bool()> storeCoverBuffer) const;
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon) const;

--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -9,6 +9,8 @@
 
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
+#include "components/icons/book_finished24.h"
+#include "components/icons/book_reading24.h"
 #include "components/icons/cover.h"
 #include "fontIds.h"
 
@@ -19,8 +21,9 @@ constexpr int cornerRadius = 6;
 }  // namespace
 
 void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                                           const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                           bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                           const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex,
+                                           bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                                           std::function<bool()> storeCoverBuffer) const {
   const int tileWidth = (rect.width - 2 * Lyra3CoversMetrics::values.contentSidePadding) / 3;
   const int tileY = rect.y;
   const bool hasContinueReading = !recentBooks.empty();
@@ -73,6 +76,22 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
                             tileWidth - 2 * hPaddingInSelection, 2 * Lyra3CoversMetrics::values.homeCoverHeight / 3,
                             true);
           renderer.drawIcon(CoverIcon, tileX + hPaddingInSelection + 24, tileY + hPaddingInSelection + 24, 32, 32);
+        }
+
+        // Overlay reading status icon (Reading or Finished) at the bottom-right of each cover
+        if (i < static_cast<int>(bookStatuses.size())) {
+          constexpr int iconSize = 24;
+          constexpr int iconMargin = 4;
+          const int iconX = tileX + tileWidth - hPaddingInSelection - iconSize - iconMargin;
+          const int iconY =
+              tileY + hPaddingInSelection + Lyra3CoversMetrics::values.homeCoverHeight - iconSize - iconMargin;
+          if (bookStatuses[i] == ReadingStatus::Reading) {
+            renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
+            renderer.drawIcon(BookReading24Icon, iconX, iconY, iconSize, iconSize);
+          } else if (bookStatuses[i] == ReadingStatus::Finished) {
+            renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
+            renderer.drawIcon(BookFinished24Icon, iconX, iconY, iconSize, iconSize);
+          }
         }
       }
 

--- a/src/components/themes/lyra/Lyra3CoversTheme.h
+++ b/src/components/themes/lyra/Lyra3CoversTheme.h
@@ -43,6 +43,7 @@ constexpr ThemeMetrics values = {.batteryWidth = 16,
 class Lyra3CoversTheme : public LyraTheme {
  public:
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                           const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                           const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex, bool& coverRendered,
+                           bool& coverBufferStored, bool& bufferRestored,
                            std::function<bool()> storeCoverBuffer) const override;
 };

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -339,9 +339,8 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
       const int actualIconSize = isReadingStatusIcon ? listIconSize : iconSize;
       const uint8_t* iconBitmap = iconForName(icon, actualIconSize);
       if (iconBitmap != nullptr) {
-        const int actualIconY = (rowSubtitle != nullptr && isReadingStatusIcon)
-                                    ? itemY + (rowHeight - actualIconSize) / 2
-                                    : itemY + iconY;
+        const int actualIconY =
+            (rowSubtitle != nullptr && isReadingStatusIcon) ? itemY + (rowHeight - actualIconSize) / 2 : itemY + iconY;
         renderer.drawIcon(iconBitmap, rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection,
                           actualIconY, actualIconSize, actualIconSize);
       }

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -333,10 +333,17 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
     if (rowIcon != nullptr) {
       UIIcon icon = rowIcon(i);
-      const uint8_t* iconBitmap = iconForName(icon, iconSize);
+      // 読書状態アイコンは 24x24 のみ用意されているため、subtitle 行でも 24px で描画する
+      const bool isReadingStatusIcon =
+          (icon == UIIcon::BookUnread || icon == UIIcon::BookReading || icon == UIIcon::BookFinished);
+      const int actualIconSize = isReadingStatusIcon ? listIconSize : iconSize;
+      const uint8_t* iconBitmap = iconForName(icon, actualIconSize);
       if (iconBitmap != nullptr) {
+        const int actualIconY = (rowSubtitle != nullptr && isReadingStatusIcon)
+                                    ? itemY + (rowHeight - actualIconSize) / 2
+                                    : itemY + iconY;
         renderer.drawIcon(iconBitmap, rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection,
-                          itemY + iconY, iconSize, iconSize);
+                          actualIconY, actualIconSize, actualIconSize);
       }
     }
 

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -449,8 +449,9 @@ void LyraTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
 }
 
 void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                                    const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                    bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                    const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex,
+                                    bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                                    std::function<bool()> storeCoverBuffer) const {
   const int tileWidth = rect.width - 2 * LyraMetrics::values.contentSidePadding;
   const int tileHeight = rect.height;
   const int tileY = rect.y;
@@ -498,6 +499,21 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
                           tileY + hPaddingInSelection + (LyraMetrics::values.homeCoverHeight / 3), coverWidth,
                           2 * LyraMetrics::values.homeCoverHeight / 3, true);
         renderer.drawIcon(CoverIcon, tileX + hPaddingInSelection + 24, tileY + hPaddingInSelection + 24, 32, 32);
+      }
+
+      // Overlay reading status icon (Reading or Finished) at the bottom-right of the cover
+      if (!bookStatuses.empty()) {
+        constexpr int iconSize = 24;
+        constexpr int iconMargin = 4;
+        const int iconX = tileX + hPaddingInSelection + coverWidth - iconSize - iconMargin;
+        const int iconY = tileY + hPaddingInSelection + LyraMetrics::values.homeCoverHeight - iconSize - iconMargin;
+        if (bookStatuses[0] == ReadingStatus::Reading) {
+          renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
+          renderer.drawIcon(BookReading24Icon, iconX, iconY, iconSize, iconSize);
+        } else if (bookStatuses[0] == ReadingStatus::Finished) {
+          renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
+          renderer.drawIcon(BookFinished24Icon, iconX, iconY, iconSize, iconSize);
+        }
       }
 
       coverBufferStored = storeCoverBuffer();

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -61,7 +61,8 @@ class LyraTheme : public BaseTheme {
                       const std::function<std::string(int index)>& buttonLabel,
                       const std::function<UIIcon(int index)>& rowIcon) const override;
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
-                           const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
+                           const std::vector<ReadingStatus>& bookStatuses, const int selectorIndex, bool& coverRendered,
+                           bool& coverBufferStored, bool& bufferRestored,
                            std::function<bool()> storeCoverBuffer) const override;
   void drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) const;
   Rect drawPopup(const GfxRenderer& renderer, const char* message) const override;


### PR DESCRIPTION
## 概要

ホーム画面の「最近の本」表示にも、ファイル一覧で実装済みの読書状態アイコンを表示するようにした。

- LyraTheme: 単一カバーの右下隅にアイコンを重ねる
- Lyra3CoversTheme: 各カバーの右下隅にアイコンを重ねる
- BaseTheme(Classic): signatureだけ追従（オーバーレイ実装は今回見送り）
- Reading（読書中）/ Finished（読了）の場合のみアイコンを表示。Unreadは非表示。

## 関連 Issue

closes #48

## テストプラン

- [ ] 実機ホーム画面で、未読書籍のカバーにアイコンが出ないこと
- [ ] 数ページ読んだ書籍に「開いた本」アイコンが表示されること
- [ ] 末尾まで読んだ書籍に「チェック付き本」アイコンが表示されること
- [ ] Lyra3Coversテーマで複数のカバーそれぞれに対応するアイコンが出ること