### PR TITLE
feat: 本の末尾でアーカイブ／削除確認ダイアログを表示

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -360,11 +360,14 @@ void EpubReaderActivity::loop() {
     return;
   }
 
-  // At end of the book, forward button shows archive/delete prompt and back button returns to last page
+  // At end of the book, forward direction shows archive/delete prompt and back direction returns to last page.
+  // 縦書きモードでは物理ボタンと進む方向が逆転する（pageTurn() の挙動と揃える）
   if (currentSpineIndex > 0 && currentSpineIndex >= epub->getSpineItemsCount()) {
-    if (nextTriggered) {
+    const bool advanceTriggered = verticalMode ? prevTriggered : nextTriggered;
+    const bool retreatTriggered = verticalMode ? nextTriggered : prevTriggered;
+    if (advanceTriggered) {
       showEndOfBookConfirmation();
-    } else {
+    } else if (retreatTriggered) {
       currentSpineIndex = epub->getSpineItemsCount() - 1;
       nextPageNumber = UINT16_MAX;
       requestUpdate();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -360,10 +360,10 @@ void EpubReaderActivity::loop() {
     return;
   }
 
-  // At end of the book, forward button goes home and back button returns to last page
+  // At end of the book, forward button shows archive/delete prompt and back button returns to last page
   if (currentSpineIndex > 0 && currentSpineIndex >= epub->getSpineItemsCount()) {
     if (nextTriggered) {
-      onGoHome();
+      showEndOfBookConfirmation();
     } else {
       currentSpineIndex = epub->getSpineItemsCount() - 1;
       nextPageNumber = UINT16_MAX;
@@ -1224,4 +1224,64 @@ void EpubReaderActivity::restoreSavedPosition() {
     section.reset();
   }
   requestUpdate();
+}
+
+void EpubReaderActivity::showEndOfBookConfirmation() {
+  if (!epub) {
+    onGoHome();
+    return;
+  }
+  const std::string filepath = epub->getPath();
+
+  auto handler = [this, filepath](const ActivityResult& res) {
+    if (!res.isCancelled) {
+      // Right ボタン → 削除
+      deleteCurrentBookFile(filepath);
+      onGoHome();
+    } else if (auto* menu = std::get_if<MenuResult>(&res.data)) {
+      if (menu->action == ConfirmationActivity::RESULT_NEVER) {
+        // Left ボタン → アーカイブ
+        archiveCurrentBookFile(filepath);
+        onGoHome();
+      } else {
+        onGoHome();
+      }
+    } else {
+      // Back ボタン → ホームへ戻る
+      onGoHome();
+    }
+  };
+
+  startActivityForResult(std::make_unique<ConfirmationActivity>(renderer, mappedInput, tr(STR_END_OF_BOOK), "",
+                                                                tr(STR_ARCHIVE), tr(STR_DELETE), tr(STR_CANCEL)),
+                         handler);
+}
+
+void EpubReaderActivity::archiveCurrentBookFile(const std::string& filepath) {
+  if (epub) {
+    epub->clearCache();
+  }
+  const size_t lastSlash = filepath.find_last_of('/');
+  const std::string filename = (lastSlash == std::string::npos) ? filepath : filepath.substr(lastSlash + 1);
+  const std::string destPath = "/Archived/" + filename;
+  Storage.mkdir("/Archived");
+  if (Storage.exists(destPath.c_str())) {
+    Storage.remove(destPath.c_str());
+  }
+  if (Storage.rename(filepath.c_str(), destPath.c_str())) {
+    LOG_DBG("ERA", "Archived to: %s", destPath.c_str());
+  } else {
+    LOG_ERR("ERA", "Failed to archive: %s", filepath.c_str());
+  }
+}
+
+void EpubReaderActivity::deleteCurrentBookFile(const std::string& filepath) {
+  if (epub) {
+    epub->clearCache();
+  }
+  if (Storage.remove(filepath.c_str())) {
+    LOG_DBG("ERA", "Deleted: %s", filepath.c_str());
+  } else {
+    LOG_ERR("ERA", "Failed to delete: %s", filepath.c_str());
+  }
 }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -58,6 +58,11 @@ class EpubReaderActivity final : public Activity {
   void navigateToHref(const std::string& href, bool savePosition = false);
   void restoreSavedPosition();
 
+  // End-of-book actions
+  void showEndOfBookConfirmation();
+  void archiveCurrentBookFile(const std::string& filepath);
+  void deleteCurrentBookFile(const std::string& filepath);
+
  public:
   explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub)
       : Activity("EpubReader", renderer, mappedInput), epub(std::move(epub)) {}

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -20,6 +20,7 @@
 #include "RecentBooksStore.h"
 #include "XtcReaderChapterSelectionActivity.h"
 #include "XtcReaderMenuActivity.h"
+#include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/ScreenshotUtil.h"
@@ -149,11 +150,11 @@ void XtcReaderActivity::loop() {
     return;
   }
 
-  // At end of the book, forward button goes home and back button returns to last page
+  // At end of the book, forward button shows archive/delete prompt and back button returns to last page
   if (currentPage >= xtc->getPageCount()) {
     if (nextTriggered) {
       saveProgress(true);
-      onGoHome();
+      showEndOfBookConfirmation();
     } else {
       currentPage = xtc->getPageCount() - 1;
       requestUpdate();
@@ -426,5 +427,65 @@ void XtcReaderActivity::loadProgress() {
       }
     }
     f.close();
+  }
+}
+
+void XtcReaderActivity::showEndOfBookConfirmation() {
+  if (!xtc) {
+    onGoHome();
+    return;
+  }
+  const std::string filepath = xtc->getPath();
+
+  auto handler = [this, filepath](const ActivityResult& res) {
+    if (!res.isCancelled) {
+      // Right ボタン → 削除
+      deleteCurrentBookFile(filepath);
+      onGoHome();
+    } else if (auto* menu = std::get_if<MenuResult>(&res.data)) {
+      if (menu->action == ConfirmationActivity::RESULT_NEVER) {
+        // Left ボタン → アーカイブ
+        archiveCurrentBookFile(filepath);
+        onGoHome();
+      } else {
+        onGoHome();
+      }
+    } else {
+      // Back ボタン → ホームへ戻る
+      onGoHome();
+    }
+  };
+
+  startActivityForResult(std::make_unique<ConfirmationActivity>(renderer, mappedInput, tr(STR_END_OF_BOOK), "",
+                                                                tr(STR_ARCHIVE), tr(STR_DELETE), tr(STR_CANCEL)),
+                         handler);
+}
+
+void XtcReaderActivity::archiveCurrentBookFile(const std::string& filepath) {
+  if (xtc) {
+    xtc->clearCache();
+  }
+  const size_t lastSlash = filepath.find_last_of('/');
+  const std::string filename = (lastSlash == std::string::npos) ? filepath : filepath.substr(lastSlash + 1);
+  const std::string destPath = "/Archived/" + filename;
+  Storage.mkdir("/Archived");
+  if (Storage.exists(destPath.c_str())) {
+    Storage.remove(destPath.c_str());
+  }
+  if (Storage.rename(filepath.c_str(), destPath.c_str())) {
+    LOG_DBG("XRA", "Archived to: %s", destPath.c_str());
+  } else {
+    LOG_ERR("XRA", "Failed to archive: %s", filepath.c_str());
+  }
+}
+
+void XtcReaderActivity::deleteCurrentBookFile(const std::string& filepath) {
+  if (xtc) {
+    xtc->clearCache();
+  }
+  if (Storage.remove(filepath.c_str())) {
+    LOG_DBG("XRA", "Deleted: %s", filepath.c_str());
+  } else {
+    LOG_ERR("XRA", "Failed to delete: %s", filepath.c_str());
   }
 }

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -22,6 +22,11 @@ class XtcReaderActivity final : public Activity {
   void saveProgress(bool isFinished = false) const;
   void loadProgress();
 
+  // End-of-book actions
+  void showEndOfBookConfirmation();
+  void archiveCurrentBookFile(const std::string& filepath);
+  void deleteCurrentBookFile(const std::string& filepath);
+
  public:
   explicit XtcReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Xtc> xtc)
       : Activity("XtcReader", renderer, mappedInput), xtc(std::move(xtc)) {}


### PR DESCRIPTION
## 概要

本の末尾(End of Book)に到達した状態で「次へ」を押した際に、即座にホームへ戻るのではなく ConfirmationActivity を起動し、ユーザーがアーカイブ／削除／キャンセルを選べるようにした。

- 右ボタン: 削除 (ファイル削除 + キャッシュクリア)
- 左ボタン: アーカイブ (/Archived/ ディレクトリへ移動 + キャッシュクリア)
- 戻るボタン: キャンセル (ホームへ戻る)
- EPUB / XTC 両方のリーダーで対応

## 関連 Issue

closes #47

## テストプラン

- [ ] EPUB を末尾まで読み「次へ」押下で確認ダイアログが出ること
- [ ] 「削除」を選んでファイル一覧から消えること
- [ ] 「アーカイブ」を選んで /Archived/ に移動すること
- [ ] 「キャンセル」(Back)でホームへ戻ること
- [ ] XTC でも同じ動作になること