### PR TITLE
feat: improve EPUB Optimizer image quality (downsampling, JPEG 90%, unsharp mask)

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1542,7 +1542,7 @@
           <div class="convert-settings" id="convertSettings" style="display:block;">
             <span>⚫ True-Grayscale</span>
           <span id="optimizerResolutionInfo">📏 Max 480×800px</span>
-          <span>📦 85% JPEG</span>
+          <span>📦 90% JPEG</span>
           <span>🔧 Fix SVG</span>
         </div>
         <!-- Advanced Settings Content -->
@@ -1555,12 +1555,13 @@
               <button class="quality-preset" data-value="45" onclick="setQualityPreset(45)" title="Low quality">45%</button>
               <button class="quality-preset" data-value="60" onclick="setQualityPreset(60)" title="Medium-low quality">60%</button>
               <button class="quality-preset" data-value="75" onclick="setQualityPreset(75)" title="Medium quality">75%</button>
-              <button class="quality-preset active" data-value="85" onclick="setQualityPreset(85)" title="High quality">85%</button>
+              <button class="quality-preset" data-value="85" onclick="setQualityPreset(85)" title="High quality">85%</button>
+              <button class="quality-preset active" data-value="90" onclick="setQualityPreset(90)" title="High quality (e-ink default)">90%</button>
               <button class="quality-preset" data-value="95" onclick="setQualityPreset(95)" title="Maximum quality">95%</button>
             </div>
             <!-- Hidden inputs to maintain compatibility -->
-            <input type="hidden" id="qualitySlider" value="85">
-            <input type="hidden" id="qualityInput" value="85">
+            <input type="hidden" id="qualitySlider" value="90">
+            <input type="hidden" id="qualityInput" value="90">
           </div>
           <!-- Grayscale Toggle (commented for e-ink optimization, kept for compatibility with other devices/web apps)
           <div class="advanced-setting-row" style="display:none;">
@@ -1969,7 +1970,7 @@
   function openUploadModal() {
     // Reset converter variables to defaults
     ENABLE_GRAYSCALE = true;
-    JPEG_QUALITY = 85;
+    JPEG_QUALITY = 90;
     HANDEDNESS = 'right';
     OVERLAP_PERCENT = 5;
     imageStates = {};
@@ -2066,8 +2067,8 @@
       advancedOptionsToggle.style.pointerEvents = 'none';
     }
     // Reset to defaults
-    document.getElementById('qualitySlider').value = 85;
-    document.getElementById('qualityInput').value = 85;
+    document.getElementById('qualitySlider').value = 90;
+    document.getElementById('qualityInput').value = 90;
     setHandedness('right');
     setOverlap(5);
     // Update converter variables
@@ -3289,7 +3290,7 @@ function buildXtcContainer(pagesData, width, height, isRtl, sourceFilename) {
 // Default conversion settings
 const DEFAULT_MAX_WIDTH = 480;
 const DEFAULT_MAX_HEIGHT = 800;
-const DEFAULT_JPEG_QUALITY = 85;
+const DEFAULT_JPEG_QUALITY = 90;
 const DEFAULT_ENABLE_GRAYSCALE = true;
 // Note: Overlap is now always centered distribution (min 5%)
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1543,6 +1543,7 @@
             <span>⚫ True-Grayscale</span>
           <span id="optimizerResolutionInfo">📏 Max 480×800px</span>
           <span>📦 90% JPEG</span>
+          <span id="sharpenStatusLabel">✨ Sharpen</span>
           <span>🔧 Fix SVG</span>
         </div>
         <!-- Advanced Settings Content -->
@@ -1577,6 +1578,19 @@
             </div>
           </div>
           -->
+          <!-- Sharpen Toggle -->
+          <div class="advanced-setting-row" id="sharpenSettingRow">
+            <div class="setting-toggle">
+              <div>
+                <div class="setting-title">✨ Sharpen</div>
+                <div class="setting-desc">Unsharp mask for crisper text and lines (recommended for e-ink)</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="sharpenToggle" checked onchange="updateQualitySettings()">
+                <span class="toggle-slider"></span>
+              </label>
+            </div>
+          </div>
           <!-- Rotation Direction -->
           <div class="advanced-setting-row" id="rotationSettingRow">
             <div class="setting-title">↻ Rotation Direction</div>
@@ -1971,6 +1985,7 @@
     // Reset converter variables to defaults
     ENABLE_GRAYSCALE = true;
     JPEG_QUALITY = 90;
+    ENABLE_SHARPEN = true;
     HANDEDNESS = 'right';
     OVERLAP_PERCENT = 5;
     imageStates = {};
@@ -2069,6 +2084,8 @@
     // Reset to defaults
     document.getElementById('qualitySlider').value = 90;
     document.getElementById('qualityInput').value = 90;
+    const sharpenToggleReset = document.getElementById('sharpenToggle');
+    if (sharpenToggleReset) sharpenToggleReset.checked = true;
     setHandedness('right');
     setOverlap(5);
     // Update converter variables
@@ -2171,6 +2188,14 @@
     // Update converter variables (used by processImage and applyGrayscale)
     JPEG_QUALITY = parseInt(quality, 10);
     ENABLE_GRAYSCALE = true; // Always grayscale for e-ink
+    const sharpenToggle = document.getElementById('sharpenToggle');
+    ENABLE_SHARPEN = sharpenToggle ? sharpenToggle.checked : true;
+
+    // Reflect sharpen state in the summary chip
+    const sharpenStatusLabel = document.getElementById('sharpenStatusLabel');
+    if (sharpenStatusLabel) {
+      sharpenStatusLabel.style.display = ENABLE_SHARPEN ? '' : 'none';
+    }
   }
 
   function setHandedness(value) {
@@ -3292,6 +3317,9 @@ const DEFAULT_MAX_WIDTH = 480;
 const DEFAULT_MAX_HEIGHT = 800;
 const DEFAULT_JPEG_QUALITY = 90;
 const DEFAULT_ENABLE_GRAYSCALE = true;
+const DEFAULT_ENABLE_SHARPEN = true;
+// Sharpen 強度。0.4 は控えめに効くが、e-ink の文字輪郭を引き締める量。
+const SHARPEN_AMOUNT = 0.4;
 // Note: Overlap is now always centered distribution (min 5%)
 
 // Dynamic conversion settings (updated by UI)
@@ -3299,6 +3327,7 @@ let MAX_WIDTH = DEFAULT_MAX_WIDTH;
 let MAX_HEIGHT = DEFAULT_MAX_HEIGHT;
 let JPEG_QUALITY = DEFAULT_JPEG_QUALITY;
 let ENABLE_GRAYSCALE = DEFAULT_ENABLE_GRAYSCALE;
+let ENABLE_SHARPEN = DEFAULT_ENABLE_SHARPEN;
 let HANDEDNESS = 'right'; // 'right' = clockwise (right-handed), 'left' = counter-clockwise (left-handed)
 let OVERLAP_PERCENT = 5; // Minimum overlap percentage for splits (5%, 10%, 15%)
 
@@ -4187,6 +4216,41 @@ function applyGrayscale(ctx, width, height) {
   ctx.putImageData(imageData, 0, 0);
 }
 
+// 軽量 unsharp mask: 3x3 box blur をベースにエッジを強調する。
+// グレースケール画像を前提とし、輝度のみで処理することで R/G/B を 1 回でまとめて更新できる。
+// applyGrayscale の直後に呼ぶこと。
+function applySharpen(ctx, width, height) {
+  if (!ENABLE_SHARPEN) return;
+  if (width < 3 || height < 3) return;
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  // 元の輝度を別バッファへ退避（box blur の参照用）
+  const luma = new Uint8ClampedArray(width * height);
+  for (let i = 0, j = 0; i < data.length; i += 4, j++) {
+    luma[j] = data[i];
+  }
+  const amount = SHARPEN_AMOUNT;
+  for (let y = 1; y < height - 1; y++) {
+    let rowIdx = y * width;
+    for (let x = 1; x < width - 1; x++) {
+      const idx = rowIdx + x;
+      const sum =
+        luma[idx - width - 1] + luma[idx - width] + luma[idx - width + 1] +
+        luma[idx - 1]         + luma[idx]         + luma[idx + 1] +
+        luma[idx + width - 1] + luma[idx + width] + luma[idx + width + 1];
+      const blur = sum * (1 / 9);
+      let val = luma[idx] + (luma[idx] - blur) * amount;
+      if (val < 0) val = 0; else if (val > 255) val = 255;
+      const v = val | 0;
+      const dstIdx = idx * 4;
+      data[dstIdx] = v;
+      data[dstIdx + 1] = v;
+      data[dstIdx + 2] = v;
+    }
+  }
+  ctx.putImageData(imageData, 0, 0);
+}
+
 // Process single image - returns array of {data, suffix} objects
 const IMAGE_LOAD_TIMEOUT_MS = 30000; // 30 second timeout for image loading
 async function processImage(data, imageState = 0, imagePath = '') {
@@ -4250,6 +4314,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         rotCtx.drawImage(scaledCanvas, 0, 0);
         rotCtx.setTransform(1, 0, 0, 1, 0, 0); // Reset transform
         applyGrayscale(rotCtx, rotW, rotH);
+        applySharpen(rotCtx, rotW, rotH);
 
         // Step 3: If WIDTH > MAX_WIDTH, split vertically
         if (rotW <= MAX_WIDTH) {
@@ -4349,6 +4414,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         scaledCtx.fillRect(0, 0, scaledW, scaledH);
         drawImageHighQuality(scaledCtx, img, origW, origH, 0, 0, scaledW, scaledH);
         applyGrayscale(scaledCtx, scaledW, scaledH);
+        applySharpen(scaledCtx, scaledW, scaledH);
 
         // Check if split needed
         if (scaledW <= MAX_WIDTH) {
@@ -4448,6 +4514,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         if (fitsInScreen) {
           // Already fits after rotation - just apply grayscale
           applyGrayscale(rotCtx, rotW, rotH);
+          applySharpen(rotCtx, rotW, rotH);
           const blob = await new Promise(res => rotCanvas.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));
           const arrBuf = await blob.arrayBuffer();
           resolve({
@@ -4468,6 +4535,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
           scaledCtx.fillRect(0, 0, newW, newH);
           drawImageHighQuality(scaledCtx, rotCanvas, rotW, rotH, 0, 0, newW, newH);
           applyGrayscale(scaledCtx, newW, newH);
+          applySharpen(scaledCtx, newW, newH);
 
           const blob = await new Promise(res => scaledCanvas.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));
           const arrBuf = await blob.arrayBuffer();
@@ -4494,6 +4562,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
           ctx.fillRect(0, 0, origW, origH);
           ctx.drawImage(img, 0, 0);
           applyGrayscale(ctx, origW, origH);
+          applySharpen(ctx, origW, origH);
 
           const blob = await new Promise(res => c.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));
           const arrBuf = await blob.arrayBuffer();
@@ -4515,6 +4584,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
           ctx.fillRect(0, 0, newW, newH);
           drawImageHighQuality(ctx, img, origW, origH, 0, 0, newW, newH);
           applyGrayscale(ctx, newW, newH);
+          applySharpen(ctx, newW, newH);
 
           const blob = await new Promise(res => c.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));
           const arrBuf = await blob.arrayBuffer();
@@ -4545,7 +4615,7 @@ async function convertEpubFile(file, progressCallback) {
   clearLog();
   showLog();
   log(`<strong>${file.name}</strong> <span class="log-detail">(${formatBytes(originalSize)})</span>`, '', 'INFO');
-  log(`Quality: ${JPEG_QUALITY}% | Overlap: ${OVERLAP_PERCENT}% | Rotation: ${HANDEDNESS === 'right' ? 'CW' : 'CCW'} | Grayscale: ${ENABLE_GRAYSCALE ? 'ON' : 'OFF'}`, '', 'INFO');
+  log(`Quality: ${JPEG_QUALITY}% | Overlap: ${OVERLAP_PERCENT}% | Rotation: ${HANDEDNESS === 'right' ? 'CW' : 'CCW'} | Grayscale: ${ENABLE_GRAYSCALE ? 'ON' : 'OFF'} | Sharpen: ${ENABLE_SHARPEN ? 'ON' : 'OFF'}`, '', 'INFO');
 
   const zip = await JSZip.loadAsync(file);
   const renamed = {};

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4132,6 +4132,43 @@ function ensureCoverMetaRegex(o) {
   return { o, fixed: false };
 }
 
+// 高品質ダウンサンプリング: 縮小率が 0.5 未満の場合は中間サイズを経由して段階的に縮小する。
+// drawImage の bilinear 補間は 2x を超える縮小でエイリアシング・ぼやけが発生するため、
+// 1/2 ずつ縮小していくことで実質的にミップマップ的な平滑化を得る。
+// destCtx は描画先 Canvas のコンテキスト。src は Image または Canvas。
+function drawImageHighQuality(destCtx, src, srcW, srcH, destX, destY, destW, destH) {
+  const scaleX = destW / srcW;
+  const scaleY = destH / srcH;
+  // 拡大もしくは緩やかな縮小は通常 drawImage で十分
+  if (scaleX >= 0.5 && scaleY >= 0.5) {
+    destCtx.imageSmoothingEnabled = true;
+    destCtx.imageSmoothingQuality = 'high';
+    destCtx.drawImage(src, 0, 0, srcW, srcH, destX, destY, destW, destH);
+    return;
+  }
+  // 段階縮小: 1/2 ずつ縮小しながら最終サイズの 2 倍を超えなくなるまで繰り返す
+  let curCanvas = src;
+  let curW = srcW;
+  let curH = srcH;
+  while (curW > destW * 2 && curH > destH * 2) {
+    const nextW = Math.max(destW, Math.floor(curW / 2));
+    const nextH = Math.max(destH, Math.floor(curH / 2));
+    const next = document.createElement('canvas');
+    next.width = nextW;
+    next.height = nextH;
+    const nctx = next.getContext('2d');
+    nctx.imageSmoothingEnabled = true;
+    nctx.imageSmoothingQuality = 'high';
+    nctx.drawImage(curCanvas, 0, 0, curW, curH, 0, 0, nextW, nextH);
+    curCanvas = next;
+    curW = nextW;
+    curH = nextH;
+  }
+  destCtx.imageSmoothingEnabled = true;
+  destCtx.imageSmoothingQuality = 'high';
+  destCtx.drawImage(curCanvas, 0, 0, curW, curH, destX, destY, destW, destH);
+}
+
 // Apply grayscale to canvas image data
 function applyGrayscale(ctx, width, height) {
   if (!ENABLE_GRAYSCALE) return;
@@ -4184,11 +4221,9 @@ async function processImage(data, imageState = 0, imagePath = '') {
         scaledCanvas.width = scaledW;
         scaledCanvas.height = scaledH;
         const scaledCtx = scaledCanvas.getContext('2d');
-        scaledCtx.imageSmoothingEnabled = true;
-        scaledCtx.imageSmoothingQuality = 'high';
         scaledCtx.fillStyle = '#FFF';
         scaledCtx.fillRect(0, 0, scaledW, scaledH);
-        scaledCtx.drawImage(img, 0, 0, origW, origH, 0, 0, scaledW, scaledH);
+        drawImageHighQuality(scaledCtx, img, origW, origH, 0, 0, scaledW, scaledH);
 
         // Step 2: Rotate 90° CW or CCW
         const rotW = scaledH;
@@ -4309,11 +4344,9 @@ async function processImage(data, imageState = 0, imagePath = '') {
         scaledCanvas.width = scaledW;
         scaledCanvas.height = scaledH;
         const scaledCtx = scaledCanvas.getContext('2d');
-        scaledCtx.imageSmoothingEnabled = true;
-        scaledCtx.imageSmoothingQuality = 'high';
         scaledCtx.fillStyle = '#FFF';
         scaledCtx.fillRect(0, 0, scaledW, scaledH);
-        scaledCtx.drawImage(img, 0, 0, origW, origH, 0, 0, scaledW, scaledH);
+        drawImageHighQuality(scaledCtx, img, origW, origH, 0, 0, scaledW, scaledH);
         applyGrayscale(scaledCtx, scaledW, scaledH);
 
         // Check if split needed
@@ -4430,11 +4463,9 @@ async function processImage(data, imageState = 0, imagePath = '') {
           scaledCanvas.width = newW;
           scaledCanvas.height = newH;
           const scaledCtx = scaledCanvas.getContext('2d');
-          scaledCtx.imageSmoothingEnabled = true;
-          scaledCtx.imageSmoothingQuality = 'high';
           scaledCtx.fillStyle = '#FFF';
           scaledCtx.fillRect(0, 0, newW, newH);
-          scaledCtx.drawImage(rotCanvas, 0, 0, newW, newH);
+          drawImageHighQuality(scaledCtx, rotCanvas, rotW, rotH, 0, 0, newW, newH);
           applyGrayscale(scaledCtx, newW, newH);
 
           const blob = await new Promise(res => scaledCanvas.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));
@@ -4479,11 +4510,9 @@ async function processImage(data, imageState = 0, imagePath = '') {
           c.width = newW;
           c.height = newH;
           const ctx = c.getContext('2d');
-          ctx.imageSmoothingEnabled = true;
-          ctx.imageSmoothingQuality = 'high';
           ctx.fillStyle = '#FFF';
           ctx.fillRect(0, 0, newW, newH);
-          ctx.drawImage(img, 0, 0, newW, newH);
+          drawImageHighQuality(ctx, img, origW, origH, 0, 0, newW, newH);
           applyGrayscale(ctx, newW, newH);
 
           const blob = await new Promise(res => c.toBlob(res, 'image/jpeg', JPEG_QUALITY / 100));


### PR DESCRIPTION
## Summary

WebUI の Optimize EPUB で画像の解像感が低下する問題を、グレースケール変換そのものではなく前後段の処理で改善する。

- **多段階ダウンサンプリング**: 縮小率が 0.5 未満の場合は中間 Canvas を経由し 1/2 ずつ縮小。Canvas drawImage の bilinear 補間によるエイリアシング・ぼやけを抑制。
- **JPEG 品質デフォルトを 85% → 90%** に引き上げ。文字・線画でのブロックノイズ／モスキートノイズを低減。85% プリセットも残しサイズ優先選択は維持。
- **Unsharp mask（デフォルト ON）**: グレースケール後に 3x3 box blur ベースの軽量シャープニング（amount=0.4）を適用。リサイズ後のエッジ甘さを補正し、e-ink 上での文字輪郭を引き締める。

## 変更点

- `src/network/html/FilesPage.html`
  - `drawImageHighQuality` ヘルパー追加（多段階縮小）
  - `applySharpen` 関数追加（unsharp mask）
  - Advanced Settings に「✨ Sharpen」トグル追加（デフォルト ON）
  - JPEG プリセット 90% を追加し active に
  - Conversion log に Sharpen 状態を表示

## Test plan

- [ ] WebUI で EPUB をアップロード → Optimize EPUB を有効化
- [ ] 大きなカラー画像を含む EPUB を変換し、変換後の画像が以前より鮮明になっていることを確認
- [ ] Advanced Settings から Sharpen トグルを OFF にして従来動作（シャープなし）と比較
- [ ] JPEG プリセット 85% に切り替え、サイズ優先動作が引き続き選択可能であることを確認
- [ ] PNG（透過あり）画像を含む EPUB で透過部が白として正しく出力されることを確認
- [ ] 実機 X3 にフラッシュし、変換した EPUB の画像表示を確認

## Definition of Done

- [x] `pio run` 成功
- [x] 変更は WebUI(HTML) のみ、ESP32 側ロジック変更なし
- [ ] 実機での画像表示確認（人手）

🤖 Generated with [Claude Code](https://claude.com/claude-code)