### PR TITLE
feat: WebUIでのEPUB転送時、最適化をデフォルトで有効化

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1526,7 +1526,7 @@
         <div class="convert-options" id="convertOptions" style="display:none;">
           <div class="convert-row">
             <label class="convert-checkbox">
-              <input type="checkbox" id="convertBeforeUpload" onchange="toggleConvertOptions()">
+              <input type="checkbox" id="convertBeforeUpload" checked onchange="toggleConvertOptions()">
               <span>Optimize EPUB</span>
             </label>
             <span class="convert-separator">—</span>
@@ -2040,7 +2040,7 @@
     document.getElementById('progress-container').style.display = 'none';
     document.getElementById('progress-fill').style.width = '0%';
     document.getElementById('progress-fill').style.backgroundColor = '#27ae60';
-    document.getElementById('convertBeforeUpload').checked = false;
+    document.getElementById('convertBeforeUpload').checked = true;
     document.getElementById('convertInfo').style.display = 'none';
     document.getElementById('convertWarning').style.display = 'none';
     // Reset XTC conversion UI
@@ -2964,6 +2964,8 @@
     // Show/hide convert options based on file types
     if (files.length > 0 && hasEpub) {
       convertOptions.style.display = 'block';
+      // チェックボックスのデフォルトON状態をボタンラベルと詳細設定UIに反映
+      toggleConvertOptions();
     } else {
       convertOptions.style.display = 'none';
       clearImagePicker();


### PR DESCRIPTION
## Summary
- closes #59
- WebUIのファイル転送モーダルで、EPUB を選択した際の `Optimize EPUB` チェックボックスをデフォルトON状態に変更
- X3で最適化が安定動作するようになり、最適化なしでは表示できないEPUBが多いことが背景

## 変更内容
- `convertBeforeUpload` チェックボックスに `checked` 属性を付与
- `closeUploadModal` のリセット時も `true` に
- `validateFile` でEPUBが選択された際に `toggleConvertOptions()` を呼び出し、ボタンラベル(`Optimize & Upload`)と詳細設定トグルの活性状態を初期表示時から正しく同期

## Test plan
- [x] 実機ビルド・フラッシュ成功
- [x] WebUIでEPUBファイルを選択 → `Optimize EPUB` がデフォルトON、ボタンが `Optimize & Upload` 表記
- [ ] アップロード後にモーダルを再度開いてもONのまま維持される
- [ ] チェックを外した場合は通常Uploadに切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)