### PR TITLE
feat: ホーム画面の読書状態アイコンをカバーから著者・タイトル下へ移動

### DIFF
--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -77,22 +77,6 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
                             true);
           renderer.drawIcon(CoverIcon, tileX + hPaddingInSelection + 24, tileY + hPaddingInSelection + 24, 32, 32);
         }
-
-        // Overlay reading status icon (Reading or Finished) at the bottom-right of each cover
-        if (i < static_cast<int>(bookStatuses.size())) {
-          constexpr int iconSize = 24;
-          constexpr int iconMargin = 4;
-          const int iconX = tileX + tileWidth - hPaddingInSelection - iconSize - iconMargin;
-          const int iconY =
-              tileY + hPaddingInSelection + Lyra3CoversMetrics::values.homeCoverHeight - iconSize - iconMargin;
-          if (bookStatuses[i] == ReadingStatus::Reading) {
-            renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
-            renderer.drawIcon(BookReading24Icon, iconX, iconY, iconSize, iconSize);
-          } else if (bookStatuses[i] == ReadingStatus::Finished) {
-            renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
-            renderer.drawIcon(BookFinished24Icon, iconX, iconY, iconSize, iconSize);
-          }
-        }
       }
 
       coverBufferStored = storeCoverBuffer();
@@ -109,10 +93,18 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
 
       auto titleLines = renderer.wrappedText(SMALL_FONT_ID, recentBooks[i].title.c_str(), maxLineWidth, 3);
 
+      constexpr int readingStatusIconSize = 24;
+      constexpr int readingStatusIconTopMargin = 4;
+      const bool hasReadingStatusIcon =
+          i < static_cast<int>(bookStatuses.size()) &&
+          (bookStatuses[i] == ReadingStatus::Reading || bookStatuses[i] == ReadingStatus::Finished);
+
       const int titleLineHeight = renderer.getLineHeight(SMALL_FONT_ID);
       const int dynamicBlockHeight = static_cast<int>(titleLines.size()) * titleLineHeight;
+      const int readingStatusBlockHeight =
+          hasReadingStatusIcon ? (readingStatusIconSize + readingStatusIconTopMargin) : 0;
       // Add a little padding below the text inside the selection box just like the top padding (5 + hPaddingSelection)
-      const int dynamicTitleBoxHeight = dynamicBlockHeight + hPaddingInSelection + 5;
+      const int dynamicTitleBoxHeight = dynamicBlockHeight + readingStatusBlockHeight + hPaddingInSelection + 5;
 
       if (bookSelected) {
         // Draw selection box
@@ -131,6 +123,13 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
       for (const auto& line : titleLines) {
         renderer.drawText(SMALL_FONT_ID, tileX + hPaddingInSelection, currentY, line.c_str(), true);
         currentY += titleLineHeight;
+      }
+      if (hasReadingStatusIcon) {
+        currentY += readingStatusIconTopMargin;
+        const uint8_t* iconBitmap =
+            (bookStatuses[i] == ReadingStatus::Finished) ? BookFinished24Icon : BookReading24Icon;
+        renderer.drawIcon(iconBitmap, tileX + hPaddingInSelection, currentY, readingStatusIconSize,
+                          readingStatusIconSize);
       }
     }
   } else {

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -507,21 +507,6 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
         renderer.drawIcon(CoverIcon, tileX + hPaddingInSelection + 24, tileY + hPaddingInSelection + 24, 32, 32);
       }
 
-      // Overlay reading status icon (Reading or Finished) at the bottom-right of the cover
-      if (!bookStatuses.empty()) {
-        constexpr int iconSize = 24;
-        constexpr int iconMargin = 4;
-        const int iconX = tileX + hPaddingInSelection + coverWidth - iconSize - iconMargin;
-        const int iconY = tileY + hPaddingInSelection + LyraMetrics::values.homeCoverHeight - iconSize - iconMargin;
-        if (bookStatuses[0] == ReadingStatus::Reading) {
-          renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
-          renderer.drawIcon(BookReading24Icon, iconX, iconY, iconSize, iconSize);
-        } else if (bookStatuses[0] == ReadingStatus::Finished) {
-          renderer.fillRect(iconX, iconY, iconSize, iconSize, false);
-          renderer.drawIcon(BookFinished24Icon, iconX, iconY, iconSize, iconSize);
-        }
-      }
-
       coverBufferStored = storeCoverBuffer();
       coverRendered = coverBufferStored;  // Only consider it rendered if we successfully stored the buffer
     }
@@ -549,8 +534,17 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
     auto author = renderer.truncatedText(UI_10_FONT_ID, book.author.c_str(), textWidth);
     const int titleLineHeight = renderer.getLineHeight(UI_12_FONT_ID);
     const int titleBlockHeight = titleLineHeight * static_cast<int>(titleLines.size());
-    const int authorHeight = book.author.empty() ? 0 : (renderer.getLineHeight(UI_10_FONT_ID) * 3 / 2);
-    const int totalBlockHeight = titleBlockHeight + authorHeight;
+    const int authorLineHeight = renderer.getLineHeight(UI_10_FONT_ID);
+    const int authorHeight = book.author.empty() ? 0 : (authorLineHeight * 3 / 2);
+
+    constexpr int readingStatusIconSize = 24;
+    constexpr int readingStatusIconTopMargin = 8;
+    const bool hasReadingStatusIcon = !bookStatuses.empty() && (bookStatuses[0] == ReadingStatus::Reading ||
+                                                                bookStatuses[0] == ReadingStatus::Finished);
+    const int readingStatusBlockHeight =
+        hasReadingStatusIcon ? (readingStatusIconSize + readingStatusIconTopMargin) : 0;
+
+    const int totalBlockHeight = titleBlockHeight + authorHeight + readingStatusBlockHeight;
     int titleY = tileY + tileHeight / 2 - totalBlockHeight / 2;
     const int textX = tileX + hPaddingInSelection + coverWidth + LyraMetrics::values.verticalSpacing;
     for (const auto& line : titleLines) {
@@ -558,8 +552,14 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
       titleY += titleLineHeight;
     }
     if (!book.author.empty()) {
-      titleY += renderer.getLineHeight(UI_10_FONT_ID) / 2;
+      titleY += authorLineHeight / 2;
       renderer.drawText(UI_10_FONT_ID, textX, titleY, author.c_str(), true);
+      titleY += authorLineHeight;
+    }
+    if (hasReadingStatusIcon) {
+      titleY += readingStatusIconTopMargin;
+      const uint8_t* iconBitmap = (bookStatuses[0] == ReadingStatus::Finished) ? BookFinished24Icon : BookReading24Icon;
+      renderer.drawIcon(iconBitmap, textX, titleY, readingStatusIconSize, readingStatusIconSize);
     }
   } else {
     drawEmptyRecents(renderer, rect);


### PR DESCRIPTION
## Summary
- closes #61
- ホーム画面の読書中/読了アイコンを、カバー画像へのオーバーレイ表示から、著者（Lyra3CoversThemeではタイトル）の下へ移動
- アイコン背景が不透明（白塗り）で見栄えが悪かった問題を解消

> [!NOTE]
> このPRは #62 にスタックされています。マージ順は #62 → #63 です。

## 変更内容
- **LyraTheme**: 縦中央配置の `totalBlockHeight` にアイコン分（24px + 上マージン8px）を加算し、著者の下にアイコンを描画
- **Lyra3CoversTheme**: `dynamicTitleBoxHeight` にアイコン分（24px + 上マージン4px）を加算し、タイトルの下にアイコンを描画。選択枠もアイコンを含む高さに自動調整

## Test plan
- [x] 実機ビルド・フラッシュ成功
- [x] LyraTheme（メイン）で著者の下にアイコンが表示される
- [ ] Lyra3CoversThemeでタイトルの下にアイコンが表示される
- [ ] 読了済みの本でチェック付きアイコン、読書中で開いた本アイコン
- [ ] 未読の本でアイコン非表示・レイアウトが詰まる
- [ ] 選択時の枠線がアイコン分まで広がる（Lyra3Covers）

🤖 Generated with [Claude Code](https://claude.com/claude-code)