### PR TITLE
fix: X3でバッテリー100%時にUSB Serialが有効化されない問題を修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,13 +318,19 @@ void setup() {
   halTiltSensor.begin();
 
 #ifdef ENABLE_SERIAL_LOG
-  if (gpio.isUsbConnected()) {
-    Serial.begin(115200);
-    const unsigned long start = millis();
-    while (!Serial && (millis() - start) < 500) {
-      delay(10);
-    }
-  }
+  // Serial 初期化は無条件で行う。
+  //
+  // 過去の実装では gpio.isUsbConnected() で判定していたが、X3 では BQ27220 の
+  // 電流レジスタ(充電中=電流>0)を見て USB 接続を推測しているため、バッテリー
+  // 100% で充電電流が流れない状態だと USB 接続時でも Serial が有効化されず
+  // フラッシュや監視ができないという副作用があった (crosspoint-reader/#2467)。
+  //
+  // 250ms の delay は USB Serial/JTAG ペリフェラルの電源投入とホスト側の
+  // enumeration 完了を待つためのもの。cold boot で races を防ぐ。
+  // (upstream crosspoint-reader/develop より)
+  delay(250);
+  Serial.begin(115200);
+  logSerial.setTxTimeoutMs(1);  // Load-bearing: これがないと未接続時に write でブロック
 #endif
 
   LOG_INF("MAIN", "Hardware detect: %s", gpio.deviceIsX3() ? "X3" : "X4");


### PR DESCRIPTION
## Summary

X3において、バッテリー100%で `Serial.begin()` が呼ばれず、USB接続していてもフラッシュ・シリアルモニタが不可能になる問題を修正。

**根本原因**: `main.cpp:322` で `Serial.begin(115200)` の呼び出しが `gpio.isUsbConnected()` で判定されていた。X3では `HalGPIO::isUsbConnected()` が BQ27220 の Current() レジスタ (充電中=電流>0) を見て USB 接続を推測している ([HalGPIO.cpp:270-285](../lib/hal/HalGPIO.cpp))。バッテリー100%まで充電された状態だと充電電流が 0mA になり、USB を繋いでいても `isUsbConnected()` が false を返し、`Serial.begin()` が呼ばれない。

その結果、macOS/Windows/Linux 側で `/dev/cu.usbmodem*` や `COM*` として enumeration されず、`pio run -t upload` によるフラッシュや `pio device monitor` によるシリアル出力が完全に不可能になる。

公式リポジトリ [crosspoint-reader/crosspoint-reader#2467](https://github.com/crosspoint-reader/crosspoint-reader/issues/2467) で同じ問題が報告されている。upstream `develop` では既に対策済み（無条件 Serial 初期化 + 250ms delay）。その方針を本フォークにも取り込む。

## Changes

- `isUsbConnected()` ゲートを削除
- 250ms の delay を先頭に置いて USB Serial/JTAG ペリフェラルの電源投入とホスト側 enumeration 完了を待つ (cold boot race 対策)
- `logSerial.setTxTimeoutMs(1)` を追加。CDC 未接続時の write がブロックしないようにする

## Impact

- **修正**: バッテリー満充電時でも USB Serial が確実に有効になる
- **副作用**: なし（Serial.begin 自体は元々USB接続時に呼ばれていたので、無条件化しても消費電力は変わらない）

## Test plan

- [x] `pio run` (default env) warning無しで成功
- [ ] 実機フラッシュ後、バッテリー100%状態でUSB接続 → macOS で `/dev/cu.usbmodem101` として enumeration される
- [ ] 実機フラッシュ後、pio device monitor でログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)