### PR TITLE
chore: version を 0.1.8 に更新

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 0.1.3
+version = 0.1.8
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
## Summary

Serial fix (#69) を含む v0.1.8 リリース準備。platformio.ini の \`[crosspoint] version\` が 0.1.3 で長らく止まっていたのを 0.1.8 に更新。

## Impact

- \`gh_release\` env のビルドで \`CROSSPOINT_VERSION\` が \`0.1.8\` になる
- 実機の 設定 → システム 画面に表示される Firmware Version が正しくなる
- OtaUpdater の isUpdateNewer は tag_name (v0.1.8) と CROSSPOINT_VERSION (0.1.8) を比較するので、既にインストール済み端末では最新扱いになる

## Related

- Depends on: #69 (Serial fix)
- Next: v0.1.8 tag/release 作成