### PR TITLE
chore: v0.1.9 release preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Xteink X3/X4 向けの日本語EPUB閲覧に特化したフォーク。
 ### その他
 
 - **読書進捗アイコン** — ファイル一覧・最近読んだ本リストで、未読/読書中/読了をアイコンで識別可能（95%以上読了で自動判定）
+- **SDカードからのファーム更新** — SD直下に `.bin` を置いて設定メニューから選択、または起動時のリカバリーモード（電源+左側面上ボタン）で直接起動
 - Xteink X3 ハードウェアサポート（4階調グレースケール対応）
 - DS3231 RTCチップによる時刻保持（RTC搭載機のみ）
 - WiFi接続時のNTP時刻自動同期
@@ -65,6 +66,25 @@ Xteink X3/X4 向けの日本語EPUB閲覧に特化したフォーク。
 2. `firmware.bin`, `bootloader.bin`, `partitions.bin` をダウンロード
 3. Xteink をUSB-Cでパソコンに接続
 4. esptool.py または https://xteink.dve.al/ から書き込み
+
+## ファームウェア更新に困ったら
+
+**v0.1.9 未満のバージョン** をお使いの場合、既知の不具合により以下の症状で更新ができない可能性があります：
+
+- PC (macOS / Windows / Linux) で USB接続してもデバイスが認識されず、`pio` や esptool でフラッシュできない
+- Web Flasher でもシリアルポート選択画面にデバイスが出てこない
+
+### 原因
+
+X3の充電状態判定が USB Serial の初期化条件になっていたため、バッテリー100%充電時に USB CDC が構成されないバグ（v0.1.9で修正済み）。詳細は [PR #69](https://github.com/zrn-ns/crosspoint-jp/pull/69) を参照。
+
+### リカバリー手順
+
+1. **[OTA Xteink Unlocker](https://crosspointreader.com/unlocker)** にアクセスし、指示に従って **Hatch Firmware** をデバイスへフラッシュする（Wi-Fi OTA 経由）
+2. Hatch Firmware 起動後、SDカード直下に本フォークの `firmware.bin` を配置
+3. Hatch Firmware の SDファーム更新機能から `firmware.bin` を選択して書き込み
+
+書き込み完了後は v0.1.9 の SDカードファーム更新機能が使えるようになるので、以降のアップデートは容易です。
 
 ## フォントのインストール
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 0.1.8
+version = 0.1.9
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
## Summary

v0.1.9 リリース準備。

### 変更内容

- **README.md**: 
  - 「その他」に SDカードからのファーム更新機能とリカバリーモード起動を追記（#67 で追加した機能）
  - 新セクション「ファームウェア更新に困ったら」をインストール直後に追加。v0.1.9未満のバージョンで USB フラッシュ・Web Flasher が動作しない不具合（#69 で修正）について、[OTA Xteink Unlocker](https://crosspointreader.com/unlocker) → Hatch Firmware 経由のリカバリー手順を案内
- **platformio.ini**: `[crosspoint] version` を 0.1.8 → 0.1.9

### リリースフロー

このPRのマージ後：
1. dev-build ワークフローが自動発火し、Serial fix + SD ファーム更新機能 + version 0.1.9 が入った dev-YYYYMMDD-HHMMSS prerelease を作成
2. Claude が prerelease の artifacts を使って v0.1.9 正式リリース（Latest）を作成
3. 実機の OTA から取得可能に

### 含まれる機能・修正

- ✨ SDカードからのファーム更新機能 (#67 / feature/66)
- ✨ 起動時リカバリーモード（電源+側面上ボタン、#67）
- 🐛 X3でバッテリー100%時に USB Serial が有効化されない問題 (#69)

## Test plan

- [x] `pio run` (default) — SUCCESS 57s
- [ ] Merge後 dev-build がSUCCESS
- [ ] v0.1.9 タグが Latest として設定される
- [ ] /releases/latest API が v0.1.9 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)