### PR TITLE
fix: CJK超長段落EPUBで縦書きページめくり時のabort()を修正 (#72)

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -109,14 +109,17 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
                          const bool attachToPrevious) {
   if (word.empty()) return;
 
-  // Pre-allocate to match the 750-word flush threshold in characterData().
+  // Pre-allocate に合わせて容量を確保する。ChapterHtmlSlimParser の中間 flush 閾値
+  // (MID_BLOCK_FLUSH_WORDS = 400) より十分大きく、かつ realloc が起きない値にする。
+  // 過大に取ると初期割当時のヒープ圧迫（sizeof(std::string) * N ≈ 32*N bytes）と
+  // フラグメンテーションのリスクが上がるため、512 程度が最適。
   // Without reserve(), std::vector doubles capacity on each reallocation (e.g. 512→1024),
   // requiring both old and new arrays in memory simultaneously. On a fragmented 380KB heap
   // this contiguous allocation can fail and call abort() (no C++ exceptions on ESP32).
   if (words.capacity() == 0) {
-    words.reserve(800);
-    wordStyles.reserve(800);
-    wordContinues.reserve(800);
+    words.reserve(512);
+    wordStyles.reserve(512);
+    wordContinues.reserve(512);
     // rubyTexts は遅延初期化（setRubyForWordAt時にのみ割り当て）— RAM節約
   }
 
@@ -134,7 +137,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
                          const bool attachToPrevious) {
   addWord(std::move(word), fontStyle, underline, attachToPrevious);
   if (wordVerticalBehaviors.capacity() == 0) {
-    wordVerticalBehaviors.reserve(800);
+    wordVerticalBehaviors.reserve(512);
   }
   wordVerticalBehaviors.push_back(vBehavior);
 }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -26,6 +26,12 @@ constexpr size_t PARSE_BUFFER_SIZE = 1024;
 // to prevent abort() from failed allocations (no C++ exceptions on ESP32).
 constexpr size_t MIN_FREE_HEAP_FOR_PARSING = 20 * 1024;  // 20KB
 
+// words vector の capacity 上限に近付いたら中間 flush する閾値。
+// ParsedText::addWord() は 512 要素で reserve するため、その手前で flush する必要がある。
+// 超えると _M_realloc_append が発生し、1024 要素分の連続領域（~32KB）を要求してヒープ不足で abort する。
+// 青空文庫のように <p> を持たない超長段落の EPUB で顕在化する（Issue #72）。
+constexpr size_t MID_BLOCK_FLUSH_WORDS = 400;
+
 const char* BLOCK_TAGS[] = {"p", "li", "div", "br", "blockquote"};
 constexpr int NUM_BLOCK_TAGS = sizeof(BLOCK_TAGS) / sizeof(BLOCK_TAGS[0]);
 
@@ -964,6 +970,12 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
         self->currentTextBlock->addWord(cjkWord, EpdFontFamily::REGULAR);
       }
       i += charLen;
+      // 中間flush: 1 回の characterData 呼び出しで CJK 単語が大量追加される場合、
+      // characterData 末尾の flush 判定では間に合わず words vector の realloc で abort する。
+      // 青空文庫のような <p> なし超長段落 EPUB で顕在化する（Issue #72）。
+      if (self->currentTextBlock->size() >= MID_BLOCK_FLUSH_WORDS) {
+        self->flushCurrentBlockMidPage();
+      }
       continue;
     }
 
@@ -980,31 +992,32 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     i += charLen;
   }
 
-  // Flush buffered words to free memory. The standard threshold is 750 words, but when free heap
-  // is low we flush earlier to prevent abort() from vector reallocation failure (operator new
-  // cannot return nullptr without std::nothrow, and C++ exceptions are disabled on ESP32).
+  // 末尾判定: ヒープ低下時に早期flush。
+  // 通常flush（MID_BLOCK_FLUSH_WORDS 到達）はループ内で判定済みなのでここでは不要。
   const size_t wordCount = self->currentTextBlock->size();
-  const bool normalFlush = wordCount > 750;
   const bool earlyFlush = wordCount > 100 && ESP.getFreeHeap() < MIN_FREE_HEAP_FOR_PARSING * 2;
-  if (normalFlush || earlyFlush) {
+  if (earlyFlush) {
     LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
-    if (self->verticalMode) {
-      // Mid-block flush: keep the trailing partial column so that newly accumulated
-      // text continues into the same column on the next call. Without this, the partial
-      // last column would be emitted prematurely, creating visually short columns at
-      // ruby tag / chunk boundaries (Issue #51).
-      self->currentTextBlock->layoutVerticalColumns(
-          self->renderer, self->fontId, self->viewportHeight,
-          [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
-    } else {
-      const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
-      const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
-                                          ? static_cast<uint16_t>(self->viewportWidth - horizontalInset)
-                                          : self->viewportWidth;
-      self->currentTextBlock->layoutAndExtractLines(
-          self->renderer, self->fontId, effectiveWidth,
-          [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
-    }
+    self->flushCurrentBlockMidPage();
+  }
+}
+
+// Mid-block flush: 現在の text block を layout に流し込み、消費済み単語を erase する。
+// characterData のループ内でも呼ばれるため、境界での partial column を残す (includeLast=false)。
+void ChapterHtmlSlimParser::flushCurrentBlockMidPage() {
+  if (!currentTextBlock || currentTextBlock->isEmpty()) return;
+
+  if (verticalMode) {
+    currentTextBlock->layoutVerticalColumns(
+        renderer, fontId, viewportHeight,
+        [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
+  } else {
+    const int horizontalInset = currentTextBlock->getBlockStyle().totalHorizontalInset();
+    const uint16_t effectiveWidth =
+        (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+    currentTextBlock->layoutAndExtractLines(
+        renderer, fontId, effectiveWidth,
+        [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
   }
 }
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -110,6 +110,7 @@ class ChapterHtmlSlimParser {
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPartWordBuffer();
+  void flushCurrentBlockMidPage();
   void makePages();
   void flushTableAsGrid();
   // XML callbacks


### PR DESCRIPTION
## Summary

青空文庫形式のような `<p>` を持たず `<br/>` のみで区切られた CJK 縦書き EPUB を X3 で読む際、ページめくり途中で `abort()` によりクラッシュしていた問題を修正します。

## 再現条件

- Xteink X3 実機
- 縦書き（`writing-mode: vertical-rl`）
- 1 ブロックが数千 CJK 文字に達する EPUB（例: 青空文庫の「札幌」 石川啄木、`/Aozora/石川啄木/4696_札幌.epub`）
- Issue #72

## 根本原因

`ChapterHtmlSlimParser::characterData()` は expat の 1 buffer (1024B ≒ 最大 341 CJK 文字) 分をまとめて渡してくる。CJK 1 文字ごとに `ParsedText::addWord` → `words.push_back` するが、`words` は `reserve(800)` で確保されているため 800 到達時に `_M_realloc_append` が発生し、次段の 1600 要素分（`sizeof(std::string) * 1600 ≒ 51KB`）の連続領域を要求する。断片化した ~70KB のヒープでは確保に失敗し、`operator new` が `bad_alloc` を throw → C++ 例外は無効化されているため `__terminate` → `abort()`。

既存の中間 flush 判定は `characterData` **末尾**でしか実行されず、1 回の呼び出しで capacity を超えるケースには追いつかなかった。

診断ビルドで得たクラッシュ直前のスタック:
```
abort() ← __terminate ← operator new (bad_alloc)
  ← _M_realloc_append (vector.tcc:595)
  ← ParsedText::addWord (ParsedText.cpp:125) — words.push_back
  ← ChapterHtmlSlimParser::characterData (ChapterHtmlSlimParser.cpp:964) — CJK文字追加
```

## 変更内容

- `MID_BLOCK_FLUSH_WORDS = 400` を定義し、CJK 文字追加ループ内で即座に flush 判定
- `flushCurrentBlockMidPage()` ヘルパーを導入し、末尾判定と共通化
- `words` / `wordStyles` / `wordContinues` / `wordVerticalBehaviors` の reserve を `800 → 512` に縮小（初回割当のヒープ圧を軽減 + realloc に至らない安全マージン確保）
- 末尾の `normalFlush` 判定はループ内で処理済みのため削除、`earlyFlush`（ヒープ低下時保険）のみ残す

## 検証

- [x] `pio run` が warning なしで成功
- [x] `clang-format` 適用済み
- [x] X3 実機で `/Aozora/石川啄木/4696_札幌.epub`（`<p>` 無し、CJK ~10000文字、131 個の `<ruby>`、`writing-mode:vertical-rl`）を開き、ページめくり数十回で `abort()` が発生しないことを確認

## 補足

- flush 頻度が上がることで、青空文庫形式 EPUB の初回パース時間はわずかに増加する可能性があるが、パース結果は SD キャッシュされるため再表示への影響はない
- 通常の `<p>` 区切り EPUB では、CJK 文字を 400 個連続することは稀（段落間で `startNewTextBlock` が走るため `size` がリセットされる）で挙動に変化なし

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)