### PR TITLE
chore: v0.1.10

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 0.1.9
+version = 0.1.10
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
## Summary

v0.1.9 → v0.1.10 のパッチリリース。

## 主な変更

- **fix**: CJK 超長段落 EPUB で縦書きページめくり時に abort() する不具合を修正（[#74](https://github.com/zrn-ns/crosspoint-jp/pull/74), #72）
  - 青空文庫形式の EPUB（\`<p>\` タグ無し・\`<br/>\` のみで区切られた超長段落）で \`ParsedText::words\` が capacity=800 を超えた時の \`_M_realloc_append\` が bad_alloc → abort() となる問題を修正
  - \`characterData\` の CJK 文字追加ループ中に mid-block flush（閾値 400）を導入し、reserve を 800→512 に縮小
  - 実機（X3）で \`4696_札幌.epub\` を用いて再現→修正済みを確認

## リリース後の作業

- master マージ後、tag v0.1.10 を打つ・GitHub Release を作成する（既存フロー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)