### PR TITLE
fix: OTAアップデート確認が失敗する不具合を修正

### DIFF
--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -1,0 +1,208 @@
+#include "ReleaseJsonParser.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+void safeCopy(char* dst, size_t dstSize, const char* src, size_t srcLen) {
+  size_t n = srcLen < dstSize - 1 ? srcLen : dstSize - 1;
+  memcpy(dst, src, n);
+  dst[n] = '\0';
+}
+
+}  // namespace
+
+ReleaseJsonParser::ReleaseJsonParser()
+    : parser(JsonCallbacks{this, sOnKey, sOnString, sOnNumber, sOnBool, sOnNull, sOnObjectStart, sOnObjectEnd,
+                           sOnArrayStart, sOnArrayEnd}) {
+  reset();
+}
+
+void ReleaseJsonParser::reset() {
+  parser.reset();
+  position = Position::TOP_LEVEL;
+  lastKey = LastKey::NONE;
+  depth = 0;
+  assetDepth = 0;
+  tagName[0] = '\0';
+  firmwareUrl[0] = '\0';
+  firmwareSize = 0;
+  tagFound = false;
+  firmwareFound = false;
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+void ReleaseJsonParser::feed(const char* data, size_t len) { parser.feed(data, len); }
+
+bool ReleaseJsonParser::foundTag() const { return tagFound; }
+bool ReleaseJsonParser::foundFirmware() const { return firmwareFound; }
+const char* ReleaseJsonParser::getTagName() const { return tagName; }
+const char* ReleaseJsonParser::getFirmwareUrl() const { return firmwareUrl; }
+size_t ReleaseJsonParser::getFirmwareSize() const { return firmwareSize; }
+
+void ReleaseJsonParser::commitAsset() {
+  if (strcmp(currentAssetName, "firmware.bin") == 0) {
+    memcpy(firmwareUrl, currentAssetUrl, sizeof(firmwareUrl));
+    firmwareSize = currentAssetSize;
+    firmwareFound = true;
+  }
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+// -- SAX callbacks (static trampolines) -------------------------------------
+
+void ReleaseJsonParser::sOnKey(void* ctx, const char* key, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth == 1) {
+        if (len == 8 && memcmp(key, "tag_name", 8) == 0)
+          self->lastKey = LastKey::TAG_NAME;
+        else if (len == 6 && memcmp(key, "assets", 6) == 0)
+          self->lastKey = LastKey::ASSETS;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    case Position::IN_ASSET_OBJECT:
+      if (self->assetDepth == 1) {
+        if (len == 4 && memcmp(key, "name", 4) == 0)
+          self->lastKey = LastKey::ASSET_NAME;
+        else if (len == 20 && memcmp(key, "browser_download_url", 20) == 0)
+          self->lastKey = LastKey::ASSET_URL;
+        else if (len == 4 && memcmp(key, "size", 4) == 0)
+          self->lastKey = LastKey::ASSET_SIZE;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnString(void* ctx, const char* value, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->lastKey) {
+    case LastKey::TAG_NAME:
+      if (self->position == Position::TOP_LEVEL && self->depth == 1) {
+        safeCopy(self->tagName, sizeof(self->tagName), value, len);
+        self->tagFound = true;
+      }
+      break;
+    case LastKey::ASSET_NAME:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetName, sizeof(self->currentAssetName), value, len);
+      break;
+    case LastKey::ASSET_URL:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetUrl, sizeof(self->currentAssetUrl), value, len);
+      break;
+    default:
+      break;
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNumber(void* ctx, const char* value, size_t /*len*/) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  if (self->lastKey == LastKey::ASSET_SIZE && self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1) {
+    self->currentAssetSize = static_cast<size_t>(strtoul(value, nullptr, 10));
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnBool(void* ctx, bool /*value*/) {
+  static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNull(void* ctx) { static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE; }
+
+void ReleaseJsonParser::sOnObjectStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      self->depth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::IN_ASSET_OBJECT;
+      self->assetDepth = 1;
+      self->currentAssetName[0] = '\0';
+      self->currentAssetUrl[0] = '\0';
+      self->currentAssetSize = 0;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnObjectEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) self->depth--;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      if (self->assetDepth == 0) {
+        self->commitAsset();
+        self->position = Position::IN_ASSETS_ARRAY;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->lastKey == LastKey::ASSETS && self->depth == 1) {
+        self->position = Position::IN_ASSETS_ARRAY;
+      } else {
+        self->depth++;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) self->depth--;
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::TOP_LEVEL;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}

--- a/lib/JsonParser/ReleaseJsonParser.h
+++ b/lib/JsonParser/ReleaseJsonParser.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "StreamingJsonParser.h"
+
+class ReleaseJsonParser {
+ public:
+  ReleaseJsonParser();
+
+  ReleaseJsonParser(const ReleaseJsonParser&) = delete;
+  ReleaseJsonParser& operator=(const ReleaseJsonParser&) = delete;
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool foundTag() const;
+  bool foundFirmware() const;
+  const char* getTagName() const;
+  const char* getFirmwareUrl() const;
+  size_t getFirmwareSize() const;
+
+ private:
+  enum class Position : uint8_t {
+    TOP_LEVEL,
+    IN_ASSETS_ARRAY,
+    IN_ASSET_OBJECT,
+  };
+
+  enum class LastKey : uint8_t {
+    NONE,
+    TAG_NAME,
+    ASSETS,
+    ASSET_NAME,
+    ASSET_URL,
+    ASSET_SIZE,
+  };
+
+  static void sOnKey(void* ctx, const char* key, size_t len);
+  static void sOnString(void* ctx, const char* value, size_t len);
+  static void sOnNumber(void* ctx, const char* value, size_t len);
+  static void sOnBool(void* ctx, bool value);
+  static void sOnNull(void* ctx);
+  static void sOnObjectStart(void* ctx);
+  static void sOnObjectEnd(void* ctx);
+  static void sOnArrayStart(void* ctx);
+  static void sOnArrayEnd(void* ctx);
+
+  void commitAsset();
+
+  StreamingJsonParser parser;
+
+  Position position;
+  LastKey lastKey;
+  uint8_t depth;
+  uint8_t assetDepth;
+
+  char tagName[32];
+  char firmwareUrl[512];
+  size_t firmwareSize;
+  bool tagFound;
+  bool firmwareFound;
+
+  char currentAssetName[32];
+  char currentAssetUrl[512];
+  size_t currentAssetSize;
+};

--- a/lib/JsonParser/StreamingJsonParser.cpp
+++ b/lib/JsonParser/StreamingJsonParser.cpp
@@ -1,0 +1,249 @@
+#include "StreamingJsonParser.h"
+
+#include <cstring>
+
+StreamingJsonParser::StreamingJsonParser(const JsonCallbacks& callbacks) : cb(callbacks) { reset(); }
+
+void StreamingJsonParser::reset() {
+  tokenLen = 0;
+  state = State::SCANNING;
+  expectingValue = false;
+  escaped = false;
+  tokenOverflow = false;
+  error = false;
+  nestingDepth = 0;
+  literalLen = 0;
+  literalPos = 0;
+}
+
+void StreamingJsonParser::feed(const char* data, size_t len) {
+  for (size_t i = 0; i < len && !error; ++i) {
+    char c = data[i];
+    switch (state) {
+      case State::SCANNING:
+        handleScanning(c);
+        break;
+      case State::IN_STRING_KEY:
+      case State::IN_STRING_VALUE:
+        handleStringChar(c);
+        break;
+      case State::IN_NUMBER:
+        handleNumber(c);
+        break;
+      case State::IN_LITERAL:
+        handleLiteral(c);
+        break;
+      case State::SKIP_STRING:
+        handleSkipString(c);
+        break;
+    }
+  }
+}
+
+void StreamingJsonParser::handleScanning(char c) {
+  switch (c) {
+    case '"':
+      tokenLen = 0;
+      tokenOverflow = false;
+      if (expectingValue || inArray()) {
+        state = State::IN_STRING_VALUE;
+      } else {
+        state = State::IN_STRING_KEY;
+      }
+      break;
+    case '{':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::OBJECT;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onObjectStart) cb.onObjectStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case '}':
+      if (cb.onObjectEnd) cb.onObjectEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case '[':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::ARRAY;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onArrayStart) cb.onArrayStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case ']':
+      if (cb.onArrayEnd) cb.onArrayEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case ':':
+      expectingValue = true;
+      break;
+    case ',':
+      expectingValue = false;
+      break;
+    case 't':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "true", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'f':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "false", 5);
+        literalLen = 5;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'n':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "null", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    default:
+      if ((expectingValue || inArray()) && (c == '-' || (c >= '0' && c <= '9'))) {
+        tokenLen = 0;
+        tokenOverflow = false;
+        appendToken(c);
+        state = State::IN_NUMBER;
+      }
+      break;
+  }
+}
+
+void StreamingJsonParser::handleStringChar(char c) {
+  if (escaped) {
+    escaped = false;
+    switch (c) {
+      case '"':
+      case '\\':
+      case '/':
+        appendToken(c);
+        break;
+      case 'b':
+        appendToken('\b');
+        break;
+      case 'f':
+        appendToken('\f');
+        break;
+      case 'n':
+        appendToken('\n');
+        break;
+      case 'r':
+        appendToken('\r');
+        break;
+      case 't':
+        appendToken('\t');
+        break;
+      case 'u':
+        // Pass \uXXXX through as literal characters -- we don't decode
+        // Unicode escapes since our use case only needs ASCII field matching.
+        appendToken('\\');
+        appendToken('u');
+        break;
+      default:
+        appendToken('\\');
+        appendToken(c);
+        break;
+    }
+    return;
+  }
+
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+
+  if (c == '"') {
+    emitToken();
+    return;
+  }
+
+  appendToken(c);
+}
+
+void StreamingJsonParser::handleNumber(char c) {
+  if ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E') {
+    appendToken(c);
+    return;
+  }
+
+  if (!tokenOverflow && cb.onNumber) {
+    tokenBuf[tokenLen] = '\0';
+    cb.onNumber(cb.ctx, tokenBuf, tokenLen);
+  }
+  state = State::SCANNING;
+  expectingValue = false;
+
+  handleScanning(c);
+}
+
+void StreamingJsonParser::handleLiteral(char c) {
+  if (c == literalExpected[literalPos]) {
+    ++literalPos;
+    if (literalPos == literalLen) {
+      if (literalExpected[0] == 't') {
+        if (cb.onBool) cb.onBool(cb.ctx, true);
+      } else if (literalExpected[0] == 'f') {
+        if (cb.onBool) cb.onBool(cb.ctx, false);
+      } else {
+        if (cb.onNull) cb.onNull(cb.ctx);
+      }
+      state = State::SCANNING;
+      expectingValue = false;
+    }
+  } else {
+    error = true;
+  }
+}
+
+void StreamingJsonParser::handleSkipString(char c) {
+  if (escaped) {
+    escaped = false;
+    return;
+  }
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+  if (c == '"') {
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}
+
+void StreamingJsonParser::appendToken(char c) {
+  if (tokenLen < TOKEN_BUF_SIZE - 1) {
+    tokenBuf[tokenLen++] = c;
+  } else {
+    tokenOverflow = true;
+  }
+}
+
+void StreamingJsonParser::emitToken() {
+  if (state == State::IN_STRING_KEY) {
+    if (!tokenOverflow && cb.onKey) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onKey(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+  } else {
+    if (!tokenOverflow && cb.onString) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onString(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}

--- a/lib/JsonParser/StreamingJsonParser.h
+++ b/lib/JsonParser/StreamingJsonParser.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+struct JsonCallbacks {
+  void* ctx;
+  void (*onKey)(void* ctx, const char* key, size_t len);
+  void (*onString)(void* ctx, const char* value, size_t len);
+  void (*onNumber)(void* ctx, const char* value, size_t len);
+  void (*onBool)(void* ctx, bool value);
+  void (*onNull)(void* ctx);
+  void (*onObjectStart)(void* ctx);
+  void (*onObjectEnd)(void* ctx);
+  void (*onArrayStart)(void* ctx);
+  void (*onArrayEnd)(void* ctx);
+};
+
+class StreamingJsonParser {
+ public:
+  static constexpr size_t TOKEN_BUF_SIZE = 512;
+  static constexpr size_t MAX_NESTING = 32;
+
+  explicit StreamingJsonParser(const JsonCallbacks& callbacks);
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool hasError() const { return error; }
+
+ private:
+  enum class State : uint8_t {
+    SCANNING,
+    IN_STRING_KEY,
+    IN_STRING_VALUE,
+    IN_NUMBER,
+    IN_LITERAL,
+    SKIP_STRING,
+  };
+
+  enum class Container : uint8_t {
+    NONE,
+    OBJECT,
+    ARRAY,
+  };
+
+  void handleScanning(char c);
+  void handleStringChar(char c);
+  void handleNumber(char c);
+  void handleLiteral(char c);
+  void handleSkipString(char c);
+
+  void appendToken(char c);
+  void emitToken();
+
+  bool inArray() const { return nestingDepth > 0 && nestingStack[nestingDepth - 1] == Container::ARRAY; }
+
+  JsonCallbacks cb;
+  char tokenBuf[TOKEN_BUF_SIZE];
+  size_t tokenLen;
+  State state;
+  bool expectingValue;
+  bool escaped;
+  bool tokenOverflow;
+  bool error;
+
+  Container nestingStack[MAX_NESTING];
+  uint8_t nestingDepth;
+
+  char literalExpected[6];
+  uint8_t literalLen;
+  uint8_t literalPos;
+};

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -54,6 +54,77 @@ class FileWriteStream final : public Stream {
 };
 }  // namespace
 
+bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username,
+                              const std::string& password) {
+  // Streaming variant: identical connection setup to the std::string overload,
+  // but pushes body chunks into onData instead of buffering them. Used by the
+  // OTA release-check path where TLS session heap + full-body buffer would OOM.
+  std::unique_ptr<NetworkClient> client;
+  if (UrlUtils::isHttpsUrl(url)) {
+    auto* secureClient = new NetworkClientSecure();
+    secureClient->setInsecure();
+    secureClient->setHandshakeTimeout(20);
+    client.reset(secureClient);
+  } else {
+    client.reset(new NetworkClient());
+  }
+  HTTPClient http;
+
+  http.begin(*client, url.c_str());
+  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+
+  if (!username.empty() && !password.empty()) {
+    std::string credentials = username + ":" + password;
+    String encoded = base64::encode(credentials.c_str());
+    http.addHeader("Authorization", "Basic " + encoded);
+  }
+
+  LOG_DBG("HTTP", "FetchStream: %s (heap=%d)", url.c_str(), ESP.getFreeHeap());
+  const int httpCode = http.GET();
+  lastHttpCode = httpCode;
+
+  if (httpCode != HTTP_CODE_OK) {
+    LOG_ERR("HTTP", "FetchStream failed: %d", httpCode);
+    http.end();
+    return false;
+  }
+
+  NetworkClient* stream = http.getStreamPtr();
+  uint8_t buf[512];
+  size_t total = 0;
+  bool aborted = false;
+  while (stream->available() || stream->connected()) {
+    int avail = stream->available();
+    if (avail <= 0) {
+      delay(1);
+      continue;
+    }
+    int toRead = (avail < static_cast<int>(sizeof(buf))) ? avail : static_cast<int>(sizeof(buf));
+    int bytesRead = stream->readBytes(buf, toRead);
+    if (bytesRead <= 0) break;
+    if (onData && !onData(buf, static_cast<size_t>(bytesRead))) {
+      aborted = true;
+      break;
+    }
+    total += bytesRead;
+  }
+  http.end();
+
+  if (aborted) {
+    LOG_DBG("HTTP", "FetchStream aborted by callback after %zu bytes", total);
+    return false;
+  }
+  if (total == 0) {
+    LOG_ERR("HTTP", "FetchStream: empty body");
+    lastHttpCode = -901;
+    return false;
+  }
+
+  LOG_DBG("HTTP", "FetchStream success: %zu bytes", total);
+  return true;
+}
+
 bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const std::string& username,
                               const std::string& password) {
   // Use NetworkClientSecure for HTTPS, regular NetworkClient for HTTP

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -11,6 +11,11 @@
 class HttpDownloader {
  public:
   using ProgressCallback = std::function<void(size_t downloaded, size_t total)>;
+  /// Streaming body callback: called with each response chunk as it arrives.
+  /// Return false to abort. Lets a streaming parser consume the response
+  /// without buffering the whole body (TLS session + full-body buffer would
+  /// otherwise contend for the same tight heap arena and OOM on ESP32-C3).
+  using DataCallback = std::function<bool(const uint8_t* data, size_t len)>;
 
   enum DownloadError {
     OK = 0,
@@ -34,6 +39,14 @@ class HttpDownloader {
                        const std::string& password = "");
 
   static bool fetchUrl(const std::string& url, Stream& stream, const std::string& username = "",
+                       const std::string& password = "");
+
+  /**
+   * Stream the response body to onData as it arrives, without buffering it.
+   * Use when the response is large (>10KB) or when heap is tight during TLS
+   * (OTA release JSON check, streaming JSON parse, etc.).
+   */
+  static bool fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username = "",
                        const std::string& password = "");
 
   /**

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -1,20 +1,23 @@
 #include "OtaUpdater.h"
 
-#include <ArduinoJson.h>
+// clang-format off
+// HttpDownloader.h pulls Arduino/SdFat, whose macros collide with lwip's
+// ip4_addr.h unless seen before esp_http_client (which includes lwip). Pin this
+// order; clang-format would otherwise sort the local header last and break the
+// build.
+#include "HttpDownloader.h"
 #include <Logging.h>
+#include <ReleaseJsonParser.h>
+#include <esp_http_client.h>
+#include <esp_https_ota.h>
+#include <esp_wifi.h>
+// clang-format on
 
 #include <cstring>
-
-#include "esp_http_client.h"
-#include "esp_https_ota.h"
-#include "esp_wifi.h"
+#include <string>
 
 namespace {
 constexpr char latestReleaseUrl[] = "https://api.github.com/repos/zrn-ns/crosspoint-jp/releases/latest";
-
-/* This is buffer and size holder to keep upcoming data from latestReleaseUrl */
-char* local_buf;
-int output_len;
 
 /*
  * When esp_crt_bundle.h included, it is pointing wrong header file
@@ -24,8 +27,6 @@ int output_len;
 extern "C" {
 extern esp_err_t esp_crt_bundle_attach(void* conf);
 }
-
-bool isTraditionalChineseBuild() { return strstr(CROSSPOINT_VERSION, "-tc") != nullptr; }
 
 bool parseSemver3(const char* version, int* major, int* minor, int* patch) {
   if (!version || !major || !minor || !patch) {
@@ -38,85 +39,14 @@ bool parseSemver3(const char* version, int* major, int* minor, int* patch) {
   return sscanf(p, "%d.%d.%d", major, minor, patch) == 3;
 }
 
-bool isFirmwareAssetName(const char* name) {
-  if (!name) {
-    return false;
-  }
-  const size_t len = strlen(name);
-  if (len < 13) {  // "firmware-x.bin"
-    return false;
-  }
-  return strncmp(name, "firmware", 8) == 0 && strcmp(name + len - 4, ".bin") == 0;
-}
-
-bool pickAssetByName(const JsonArrayConst& assets, const char* targetName, std::string* outUrl, size_t* outSize) {
-  for (const JsonVariantConst asset : assets) {
-    const char* name = asset["name"] | "";
-    if (strcmp(name, targetName) == 0) {
-      *outUrl = asset["browser_download_url"] | "";
-      *outSize = asset["size"] | static_cast<size_t>(0);
-      return !outUrl->empty() && *outSize > 0;
-    }
-  }
-  return false;
-}
-
-bool pickAnyFirmwareAsset(const JsonArrayConst& assets, std::string* outUrl, size_t* outSize) {
-  for (const JsonVariantConst asset : assets) {
-    const char* name = asset["name"] | "";
-    if (!isFirmwareAssetName(name)) {
-      continue;
-    }
-    *outUrl = asset["browser_download_url"] | "";
-    *outSize = asset["size"] | static_cast<size_t>(0);
-    if (!outUrl->empty() && *outSize > 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
 esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
   return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
 }
-
-esp_err_t event_handler(esp_http_client_event_t* event) {
-  /* We do interested in only HTTP_EVENT_ON_DATA event only */
-  if (event->event_id != HTTP_EVENT_ON_DATA) return ESP_OK;
-
-  if (!esp_http_client_is_chunked_response(event->client)) {
-    int content_len = esp_http_client_get_content_length(event->client);
-    int copy_len = 0;
-
-    if (local_buf == NULL) {
-      /* local_buf life span is tracked by caller checkForUpdate */
-      local_buf = static_cast<char*>(calloc(content_len + 1, sizeof(char)));
-      output_len = 0;
-      if (local_buf == NULL) {
-        LOG_ERR("OTA", "HTTP Client Out of Memory Failed, Allocation %d", content_len);
-        return ESP_ERR_NO_MEM;
-      }
-    }
-    copy_len = min(event->data_len, (content_len - output_len));
-    if (copy_len) {
-      memcpy(local_buf + output_len, event->data, copy_len);
-    }
-    output_len += copy_len;
-  } else {
-    /* Code might be hits here, It happened once (for version checking) but I need more logs to handle that */
-    int chunked_len;
-    esp_http_client_get_chunk_length(event->client, &chunked_len);
-    LOG_DBG("OTA", "esp_http_client_is_chunked_response failed, chunked_len: %d", chunked_len);
-  }
-
-  return ESP_OK;
-} /* event_handler */
 } /* namespace */
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
-  JsonDocument filter;
-  esp_err_t esp_err;
-  JsonDocument doc;
+  LOG_DBG("OTA", "Checking for update (current: %s)", CROSSPOINT_VERSION);
+
   updateAvailable = false;
   latestVersion.clear();
   otaUrl.clear();
@@ -124,91 +54,42 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   processedSize = 0;
   totalSize = 0;
 
-  esp_http_client_config_t client_config = {
-      .url = latestReleaseUrl,
-      .event_handler = event_handler,
-      /* Default HTTP client buffer size 512 byte only */
-      .buffer_size = 8192,
-      .buffer_size_tx = 8192,
-      .skip_cert_common_name_check = true,
-      .crt_bundle_attach = esp_crt_bundle_attach,
-      .keep_alive_enable = true,
-  };
-
-  /* To track life time of local_buf, dtor will be called on exit from that function */
-  struct localBufCleaner {
-    char** bufPtr;
-    ~localBufCleaner() {
-      if (*bufPtr) {
-        free(*bufPtr);
-        *bufPtr = NULL;
-      }
-    }
-  } localBufCleaner = {&local_buf};
-
-  esp_http_client_handle_t client_handle = esp_http_client_init(&client_config);
-  if (!client_handle) {
-    LOG_ERR("OTA", "HTTP Client Handle Failed");
-    return INTERNAL_UPDATE_ERROR;
-  }
-
-  esp_err = esp_http_client_set_header(client_handle, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-  if (esp_err != ESP_OK) {
-    LOG_ERR("OTA", "esp_http_client_set_header Failed : %s", esp_err_to_name(esp_err));
-    esp_http_client_cleanup(client_handle);
-    return INTERNAL_UPDATE_ERROR;
-  }
-
-  esp_err = esp_http_client_perform(client_handle);
-  if (esp_err != ESP_OK) {
-    LOG_ERR("OTA", "esp_http_client_perform Failed : %s", esp_err_to_name(esp_err));
-    esp_http_client_cleanup(client_handle);
+  // Stream the release JSON straight into the parser as it arrives.
+  // Buffering the whole body in a std::string would add a growing allocation
+  // on top of the TLS session's heap during the fetch; with -fno-exceptions an
+  // OOM there aborts. The old ArduinoJson + esp_http_client event_handler path
+  // also silently dropped chunked-transfer responses. HttpDownloader::fetchUrl
+  // handles verified-https GET, redirects, and User-Agent for us.
+  ReleaseJsonParser releaseParser;
+  const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&releaseParser](const uint8_t* data, size_t len) {
+    releaseParser.feed(reinterpret_cast<const char*>(data), len);
+    return true;
+  });
+  if (!ok) {
+    LOG_ERR("OTA", "Release check fetch failed");
     return HTTP_ERROR;
   }
 
-  /* esp_http_client_close will be called inside cleanup as well*/
-  esp_err = esp_http_client_cleanup(client_handle);
-  if (esp_err != ESP_OK) {
-    LOG_ERR("OTA", "esp_http_client_cleanup Failed : %s", esp_err_to_name(esp_err));
-    return INTERNAL_UPDATE_ERROR;
-  }
+  LOG_DBG("OTA", "Parser results: tag=%s firmware=%s", releaseParser.foundTag() ? "yes" : "no",
+          releaseParser.foundFirmware() ? "yes" : "no");
 
-  filter["tag_name"] = true;
-  filter["assets"][0]["name"] = true;
-  filter["assets"][0]["browser_download_url"] = true;
-  filter["assets"][0]["size"] = true;
-  const DeserializationError error = deserializeJson(doc, local_buf, DeserializationOption::Filter(filter));
-  if (error) {
-    LOG_ERR("OTA", "JSON parse failed: %s", error.c_str());
+  if (!releaseParser.foundTag()) {
+    LOG_ERR("OTA", "No tag_name in release JSON");
     return JSON_PARSE_ERROR;
   }
 
-  if (!doc["tag_name"].is<std::string>()) {
-    LOG_ERR("OTA", "No tag_name found");
-    return JSON_PARSE_ERROR;
-  }
-
-  if (!doc["assets"].is<JsonArray>()) {
-    LOG_ERR("OTA", "No assets found");
-    return JSON_PARSE_ERROR;
-  }
-
-  latestVersion = doc["tag_name"].as<std::string>();
-
-  const JsonArrayConst assets = doc["assets"].as<JsonArrayConst>();
-  const char* preferredAssetName = isTraditionalChineseBuild() ? "firmware-tc.bin" : "firmware-sc.bin";
-
-  if (!pickAssetByName(assets, preferredAssetName, &otaUrl, &otaSize) &&
-      !pickAssetByName(assets, "firmware.bin", &otaUrl, &otaSize) && !pickAnyFirmwareAsset(assets, &otaUrl, &otaSize)) {
-    LOG_ERR("OTA", "No firmware asset found (preferred: %s)", preferredAssetName);
+  if (!releaseParser.foundFirmware()) {
+    LOG_ERR("OTA", "No firmware.bin asset found");
     return NO_UPDATE;
   }
 
+  latestVersion = releaseParser.getTagName();
+  otaUrl = releaseParser.getFirmwareUrl();
+  otaSize = releaseParser.getFirmwareSize();
   totalSize = otaSize;
   updateAvailable = true;
 
-  LOG_DBG("OTA", "Found update: %s, asset=%s, size=%u", latestVersion.c_str(), otaUrl.c_str(),
-          static_cast<unsigned int>(otaSize));
+  LOG_DBG("OTA", "Found update: %s, asset size=%u", latestVersion.c_str(), static_cast<unsigned int>(otaSize));
   return OK;
 }
 


### PR DESCRIPTION
## Summary

設定 → アップデート確認が「アップデート失敗」表示になる問題を修正します。SDカードファーム更新機能や本家 Hatch Firmware の OTA 更新は成功していたため、マニフェスト/サーバ側でなく **リーダーの `OtaUpdater` 実装** に原因があることを特定しました。

## 主な原因

1. **HTTP chunked transfer 未対応**: [OtaUpdater.cpp:105-110](https://github.com/zrn-ns/crosspoint-jp/blob/master/src/network/OtaUpdater.cpp#L105-L110) の \`event_handler\` は chunked 経路でデータを \`local_buf\` にコピーせず捨てていた（コメントに「It happened once but I need more logs to handle that」と残っていた既知の未対応）。GitHub API が chunked を返すとレスポンスが空になり JSON parse に失敗 → FAILED 表示。
2. **TLS ヒープ + 全body保持での OOM リスク**: レスポンス全体を \`local_buf\` に確保する方式のため、断片化した ESP32-C3 のヒープで \`bad_alloc → abort()\` の可能性。C++ 例外は無効化されているため throw = 即死。本家も同じ問題を認識し既にリファクタ済み（\"Buffering the whole body in a std::string would add a growing allocation on top of the TLS session's heap during the fetch; with -fno-exceptions an OOM there aborts\"）。

## 修正内容

### 本家の解決策を取り込み
- **\`lib/JsonParser/{StreamingJsonParser,ReleaseJsonParser}\` を新規追加**（本家 crosspoint-reader/crosspoint-reader からコピー）
- **\`HttpDownloader::fetchUrl\` に \`DataCallback\` 版のオーバーロードを追加** — 512 バイトずつコールバックへ push、body 全体を保持しない
- **\`OtaUpdater::checkForUpdate()\` を streaming SAX パース方式にリライト**

### sc/tc 選択ロジックを撤廃
crosspoint-jp のリリースアセットは常に \`firmware.bin\` 1 つのみなので、crosspoint-cjk 由来の以下を削除:
- \`preferredAssetName = firmware-sc.bin / firmware-tc.bin\` の候補選択
- \`isTraditionalChineseBuild()\`
- \`isFirmwareAssetName()\`, \`pickAssetByName()\`, \`pickAnyFirmwareAsset()\` の fallback 選択ロジック

### 変更範囲を最小に
\`installUpdate()\` 側はもともと \`esp_https_ota\` による streaming 実装のため現状維持（\`render\` フラグ方式）。\`OtaUpdateActivity\` の変更は不要です。

## サイズ変化

- Flash: 6014KB → **6009KB**（約 4KB 削減、ArduinoJson の一部依存を削除）
- RAM: 変化なし（31.2%）

## 実機検証（お願い）

- [x] \`pio run\` 成功
- [x] \`clang-format\` 適用
- [x] \`~/Desktop/crosspoint-jp-ota-fix.bin\` を配置
- [ ] 実機で SD カードファーム更新経由でインストール
- [ ] 設定 → アップデート確認で 「アップデートなし」（v0.1.9 は最新）が表示されること

## 補足

本家には \`test/{streaming_json_parser,release_json_parser}/*Test.cpp\` の unit test もありますが、crosspoint-jp 側で unit test 運用がまだ無いため今回は移植を見送っています。将来的に unit test 環境を整える際は取り込み推奨です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)