### PR TITLE
fix: 青空文庫ダウンロード履歴の断片化クラッシュを解消

### DIFF
--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -493,16 +493,18 @@ static void sanitizeForFat32(const char* src, char* dest, size_t destSize) {
   dest[pos] = '\0';
 }
 
-std::string AozoraIndexManager::makeRelativePath(int workId, const char* title, const char* author) {
+bool AozoraIndexManager::makeRelativePath(int workId, const char* title, const char* author, char* out,
+                                          size_t outSize) {
+  if (!out || outSize == 0) return false;
+
   char safeAuthor[48];
   sanitizeForFat32(author, safeAuthor, sizeof(safeAuthor));
 
   char safeTitle[52];
   sanitizeForFat32(title, safeTitle, sizeof(safeTitle));
 
-  char result[160];
-  snprintf(result, sizeof(result), "%s/%d_%s.epub", safeAuthor, workId, safeTitle);
-  return std::string(result);
+  const int written = snprintf(out, outSize, "%s/%d_%s.epub", safeAuthor, workId, safeTitle);
+  return written > 0 && static_cast<size_t>(written) < outSize;
 }
 
 bool AozoraIndexManager::ensureAuthorDirectory(const char* author) {

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -1,6 +1,7 @@
 #include "AozoraIndexManager.h"
 
 #include <ArduinoJson.h>
+#include <HalStorage.h>
 #include <Logging.h>
 
 #include <algorithm>

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -1,5 +1,6 @@
 #include "AozoraIndexManager.h"
 
+#include <ArduinoJson.h>
 #include <Logging.h>
 
 #include <algorithm>
@@ -11,11 +12,26 @@ bool AozoraIndexManager::loadAndPurge() {
   downloadedIds_.clear();
   activeOffsets_.clear();
 
+  // 前回のマイグレが中断した場合の残骸を削除
+  if (Storage.exists(INDEX_TMP_PATH)) {
+    LOG_DBG("AOZORA", "Removing stale tmp file");
+    Storage.remove(INDEX_TMP_PATH);
+  }
+
   if (Storage.exists(INDEX_BIN_PATH)) {
     return loadFromBin_();
   }
 
-  LOG_DBG("AOZORA", "No index bin found, starting fresh");
+  if (Storage.exists(INDEX_PATH)) {
+    LOG_DBG("AOZORA", "Migrating legacy JSON to binary format");
+    if (migrateFromJson_()) {
+      return loadFromBin_();
+    }
+    LOG_ERR("AOZORA", "Migration failed, keeping legacy JSON");
+    return true;
+  }
+
+  LOG_DBG("AOZORA", "No index found, starting fresh");
   return true;
 }
 
@@ -198,6 +214,128 @@ bool AozoraIndexManager::loadFromBin_() {
 
   file.close();
   LOG_DBG("AOZORA", "Loaded %zu active entries from bin", activeOffsets_.size());
+  return true;
+}
+
+/**
+ * 旧 JSON 形式 (/Aozora/.aozora_index.json) をバイナリ形式にワンショット変換する。
+ *
+ * 全件を JsonDocument に一度に載せると断片化を助長するので、配列を 1 要素ずつ小さな
+ * JsonDocument でパースし逐次 bin に append する。.tmp に書き終えたら rename で
+ * atomic swap し、成功時は旧 JSON を削除する。
+ */
+bool AozoraIndexManager::migrateFromJson_() {
+  HalFile src;
+  if (!Storage.openFileForRead("AOZORA", INDEX_PATH, src)) {
+    LOG_ERR("AOZORA", "migrate: open JSON failed");
+    return false;
+  }
+
+  // 先頭の '[' までスキップ
+  int c = -1;
+  while ((c = src.read()) != -1 && c != '[') {
+  }
+  if (c != '[') {
+    LOG_ERR("AOZORA", "migrate: no array start");
+    src.close();
+    return false;
+  }
+
+  // .tmp を新規作成しヘッダを書き込む
+  Storage.remove(INDEX_TMP_PATH);  // 万が一残骸があれば削除
+  HalFile dst;
+  if (!Storage.openFileForWrite("AOZORA", INDEX_TMP_PATH, dst)) {
+    LOG_ERR("AOZORA", "migrate: open tmp for write failed");
+    src.close();
+    return false;
+  }
+  if (!writeHeader_(dst)) {
+    dst.close();
+    Storage.remove(INDEX_TMP_PATH);
+    src.close();
+    return false;
+  }
+
+  auto peekChar = [&src]() -> int {
+    const size_t pos = src.position();
+    int ch = src.read();
+    if (ch != -1) src.seekSet(pos);
+    return ch;
+  };
+
+  int migratedCount = 0;
+  bool ok = true;
+
+  while (src.available()) {
+    // 空白と ',' をスキップ、']' が来たら終了
+    while (src.available()) {
+      const int ch = peekChar();
+      if (ch == -1) break;
+      if (ch == ']') {
+        src.read();
+        goto done;  // 配列終了
+      }
+      if (ch == ',' || ch == ' ' || ch == '\r' || ch == '\n' || ch == '\t') {
+        src.read();
+        continue;
+      }
+      break;
+    }
+    if (!src.available()) break;
+
+    // 1 オブジェクトずつ小さな JsonDocument でパース
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, src);
+    if (err) {
+      LOG_ERR("AOZORA", "migrate: parse error: %s", err.c_str());
+      ok = false;
+      break;
+    }
+
+    JsonObject obj = doc.as<JsonObject>();
+    AozoraBookEntry entry;
+    memset(&entry, 0, sizeof(entry));
+    entry.workId = obj["work_id"] | 0;
+    snprintf(entry.title, sizeof(entry.title), "%s", (const char*)(obj["title"] | ""));
+    snprintf(entry.author, sizeof(entry.author), "%s", (const char*)(obj["author"] | ""));
+    snprintf(entry.filename, sizeof(entry.filename), "%s", (const char*)(obj["filename"] | ""));
+
+    // 実ファイル存在チェック（欠損は自動的にスキップ）
+    char fullPath[160];
+    snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, entry.filename);
+    if (!Storage.exists(fullPath)) {
+      LOG_DBG("AOZORA", "migrate: skip missing %s", entry.filename);
+      continue;
+    }
+
+    uint32_t offset = 0;
+    if (!appendRecord_(dst, entry, offset)) {
+      LOG_ERR("AOZORA", "migrate: appendRecord failed");
+      ok = false;
+      break;
+    }
+    migratedCount++;
+  }
+
+done:
+  dst.close();
+  src.close();
+
+  if (!ok) {
+    Storage.remove(INDEX_TMP_PATH);
+    return false;
+  }
+
+  // atomic swap: tmp を本番パスに rename
+  if (!Storage.rename(INDEX_TMP_PATH, INDEX_BIN_PATH)) {
+    LOG_ERR("AOZORA", "migrate: rename failed");
+    Storage.remove(INDEX_TMP_PATH);
+    return false;
+  }
+
+  // 旧 JSON を削除（rename 成功後）
+  Storage.remove(INDEX_PATH);
+  LOG_DBG("AOZORA", "Migrated %d entries from JSON", migratedCount);
   return true;
 }
 

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -28,8 +28,9 @@ bool AozoraIndexManager::loadAndPurge() {
     if (migrateFromJson_()) {
       return loadFromBin_();
     }
-    LOG_ERR("AOZORA", "Migration failed, keeping legacy JSON");
-    return true;
+    // 破損 JSON は再度マイグレしても同じ結果になるため、退避して SD 走査に落とす。
+    LOG_ERR("AOZORA", "Migration failed, removing corrupt JSON and falling back to directory scan");
+    Storage.remove(INDEX_PATH);
   }
 
   // 最後の砦: SD 上の EPUB ファイル配置から履歴を再構築
@@ -166,12 +167,18 @@ bool AozoraIndexManager::readEntryAt(size_t indexInActive, AozoraBookEntry& out)
     LOG_ERR("AOZORA", "readEntryAt: short read at offset %u", offset);
     return false;
   }
+  // 破損データによる over-read を防ぐため末尾を必ず null 終端する
+  out.title[sizeof(out.title) - 1] = '\0';
+  out.author[sizeof(out.author) - 1] = '\0';
+  out.filename[sizeof(out.filename) - 1] = '\0';
   return true;
 }
 
 bool AozoraIndexManager::loadFromBin_() {
-  HalFile file;
-  if (!Storage.openFileForRead("AOZORA", INDEX_BIN_PATH, file)) {
+  // 走査中に SD 上の実ファイルが欠損しているレコードを tombstone マークするため、
+  // 読み書き両用で開く。
+  HalFile file = Storage.open(INDEX_BIN_PATH, O_RDWR);
+  if (!file) {
     LOG_ERR("AOZORA", "loadFromBin: open failed");
     return false;
   }
@@ -312,6 +319,12 @@ bool AozoraIndexManager::migrateFromJson_() {
     snprintf(entry.author, sizeof(entry.author), "%s", (const char*)(obj["author"] | ""));
     snprintf(entry.filename, sizeof(entry.filename), "%s", (const char*)(obj["filename"] | ""));
 
+    // 不正な行は捨てる（workId 未設定・空文字列で filename パスが AOZORA_DIR と衝突する等）
+    if (entry.workId <= 0 || entry.filename[0] == '\0') {
+      LOG_DBG("AOZORA", "migrate: skip invalid entry workId=%d", entry.workId);
+      continue;
+    }
+
     // 実ファイル存在チェック（欠損は自動的にスキップ）
     char fullPath[160];
     snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, entry.filename);
@@ -397,7 +410,10 @@ bool AozoraIndexManager::rebuildFromDirectoryScan_() {
       continue;
     }
 
-    char authorName[48] = {};
+    // CJK UTF-8 で 47 バイトの制約は容易に超える。SdFat の LFN 上限 (255) 未満まで拡大する。
+    // ただし author が本当に長い場合は entry.author[32] で truncate されるので、その場合は
+    // 復元後に実ファイルとパスが一致せず drop される（既知の制約）。
+    char authorName[64] = {};
     authorDir.getName(authorName, sizeof(authorName));
 
     // 隠しディレクトリ (例: .Trashes) はスキップ
@@ -416,7 +432,7 @@ bool AozoraIndexManager::rebuildFromDirectoryScan_() {
         continue;
       }
 
-      char fname[96] = {};
+      char fname[128] = {};
       bookFile.getName(fname, sizeof(fname));
       bookFile.close();
 

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -59,10 +59,11 @@ bool AozoraIndexManager::addEntry(int32_t workId, const char* title, const char*
   snprintf(entry.author, sizeof(entry.author), "%s", author);
   snprintf(entry.filename, sizeof(entry.filename), "%s", filename);
 
-  HalFile file;
+  // O_TRUNC 付きで開くと既存レコードが全消失するため、O_RDWR | O_CREAT で開く
   const bool binExists = Storage.exists(INDEX_BIN_PATH);
-  if (!Storage.openFileForWrite("AOZORA", INDEX_BIN_PATH, file)) {
-    LOG_ERR("AOZORA", "addEntry: open bin for write failed");
+  HalFile file = Storage.open(INDEX_BIN_PATH, O_RDWR | O_CREAT);
+  if (!file) {
+    LOG_ERR("AOZORA", "addEntry: open bin for RW failed");
     return false;
   }
 
@@ -93,8 +94,9 @@ bool AozoraIndexManager::removeEntry(int32_t workId) {
 
   // activeOffsets_ から該当エントリを見つけて、bin ファイルの実ファイルパスを取得し
   // tombstone を書き込む。実ファイル削除もこの過程で行う。
-  HalFile file;
-  if (!Storage.openFileForWrite("AOZORA", INDEX_BIN_PATH, file)) {
+  // O_TRUNC 付きで開くと bin 全体が消えるので O_RDWR で開く。
+  HalFile file = Storage.open(INDEX_BIN_PATH, O_RDWR);
+  if (!file) {
     LOG_ERR("AOZORA", "removeEntry: open bin failed");
     return false;
   }

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -3,6 +3,10 @@
 #include <ArduinoJson.h>
 #include <Logging.h>
 
+#include <cstring>
+
+constexpr uint8_t AozoraIndexManager::BIN_HEADER_MAGIC[4];
+
 bool AozoraIndexManager::loadAndPurge() {
   entries_.clear();
 
@@ -145,4 +149,70 @@ bool AozoraIndexManager::ensureAuthorDirectory(const char* author) {
 bool AozoraIndexManager::ensureDirectory() {
   if (Storage.exists(AOZORA_DIR)) return true;
   return Storage.mkdir(AOZORA_DIR);
+}
+
+// --- バイナリ形式 I/O ヘルパ ---
+
+bool AozoraIndexManager::writeHeader_(HalFile& file) {
+  uint8_t header[BIN_HEADER_SIZE] = {
+      BIN_HEADER_MAGIC[0],
+      BIN_HEADER_MAGIC[1],
+      BIN_HEADER_MAGIC[2],
+      BIN_HEADER_MAGIC[3],
+      BIN_HEADER_VERSION,
+      0x00,
+      0x00,
+      0x00,
+  };
+  if (!file.seekSet(0)) {
+    LOG_ERR("AOZORA", "writeHeader: seek(0) failed");
+    return false;
+  }
+  if (file.write(header, sizeof(header)) != sizeof(header)) {
+    LOG_ERR("AOZORA", "writeHeader: write failed");
+    return false;
+  }
+  return true;
+}
+
+bool AozoraIndexManager::checkHeader_(HalFile& file) {
+  if (!file.seekSet(0)) return false;
+  uint8_t header[BIN_HEADER_SIZE];
+  if (file.read(header, sizeof(header)) != static_cast<int>(sizeof(header))) return false;
+  if (memcmp(header, BIN_HEADER_MAGIC, sizeof(BIN_HEADER_MAGIC)) != 0) return false;
+  if (header[4] != BIN_HEADER_VERSION) return false;
+  return true;
+}
+
+bool AozoraIndexManager::appendRecord_(HalFile& file, const AozoraBookEntry& entry, uint32_t& outOffset) {
+  const size_t endPos = file.fileSize();
+  if (!file.seekSet(endPos)) {
+    LOG_ERR("AOZORA", "appendRecord: seek(end) failed");
+    return false;
+  }
+  const uint8_t status = STATUS_ACTIVE;
+  if (file.write(&status, 1) != 1) {
+    LOG_ERR("AOZORA", "appendRecord: write status failed");
+    return false;
+  }
+  if (file.write(&entry, sizeof(entry)) != sizeof(entry)) {
+    LOG_ERR("AOZORA", "appendRecord: write entry failed");
+    return false;
+  }
+  outOffset = static_cast<uint32_t>(endPos);
+  return true;
+}
+
+bool AozoraIndexManager::markTombstone_(HalFile& file, uint32_t offset) {
+  if (!file.seekSet(offset)) {
+    LOG_ERR("AOZORA", "markTombstone: seek(%u) failed", offset);
+    return false;
+  }
+  const uint8_t status = STATUS_TOMBSTONE;
+  if (file.write(&status, 1) != 1) {
+    LOG_ERR("AOZORA", "markTombstone: write failed");
+    return false;
+  }
+  file.flush();
+  return true;
 }

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -31,6 +31,15 @@ bool AozoraIndexManager::loadAndPurge() {
     return true;
   }
 
+  // 最後の砦: SD 上の EPUB ファイル配置から履歴を再構築
+  if (Storage.exists(AOZORA_DIR)) {
+    LOG_DBG("AOZORA", "Rebuilding index from SD directory scan");
+    if (rebuildFromDirectoryScan_()) {
+      return loadFromBin_();
+    }
+    LOG_ERR("AOZORA", "Directory scan rebuild failed");
+  }
+
   LOG_DBG("AOZORA", "No index found, starting fresh");
   return true;
 }
@@ -336,6 +345,138 @@ done:
   // 旧 JSON を削除（rename 成功後）
   Storage.remove(INDEX_PATH);
   LOG_DBG("AOZORA", "Migrated %d entries from JSON", migratedCount);
+  return true;
+}
+
+/**
+ * JSON も bin も無いか壊れている場合の最終手段として、SD 上の
+ * /Aozora/著者名/workId_タイトル.epub 配置からレコードを再構築する。
+ *
+ * makeRelativePath() の命名規則を逆手にとってファイル名から workId とタイトルを
+ * 抽出する。この処理により、SD カード上に EPUB が残っていれば履歴 JSON が消えても
+ * 完全に回復できる。
+ */
+bool AozoraIndexManager::rebuildFromDirectoryScan_() {
+  HalFile rootDir;
+  if (!Storage.openFileForRead("AOZORA", AOZORA_DIR, rootDir)) {
+    LOG_ERR("AOZORA", "rebuild: open /Aozora failed");
+    return false;
+  }
+  if (!rootDir.isDirectory()) {
+    LOG_ERR("AOZORA", "rebuild: /Aozora is not a directory");
+    rootDir.close();
+    return false;
+  }
+
+  Storage.remove(INDEX_TMP_PATH);
+  HalFile dst;
+  if (!Storage.openFileForWrite("AOZORA", INDEX_TMP_PATH, dst)) {
+    LOG_ERR("AOZORA", "rebuild: open tmp failed");
+    rootDir.close();
+    return false;
+  }
+  if (!writeHeader_(dst)) {
+    dst.close();
+    Storage.remove(INDEX_TMP_PATH);
+    rootDir.close();
+    return false;
+  }
+
+  int rebuiltCount = 0;
+  bool ok = true;
+
+  rootDir.rewindDirectory();
+  HalFile authorDir = rootDir.openNextFile();
+  while (authorDir.isOpen()) {
+    if (!authorDir.isDirectory()) {
+      authorDir.close();
+      authorDir = rootDir.openNextFile();
+      continue;
+    }
+
+    char authorName[48] = {};
+    authorDir.getName(authorName, sizeof(authorName));
+
+    // 隠しディレクトリ (例: .Trashes) はスキップ
+    if (authorName[0] == '.') {
+      authorDir.close();
+      authorDir = rootDir.openNextFile();
+      continue;
+    }
+
+    authorDir.rewindDirectory();
+    HalFile bookFile = authorDir.openNextFile();
+    while (bookFile.isOpen()) {
+      if (bookFile.isDirectory()) {
+        bookFile.close();
+        bookFile = authorDir.openNextFile();
+        continue;
+      }
+
+      char fname[96] = {};
+      bookFile.getName(fname, sizeof(fname));
+      bookFile.close();
+
+      const size_t len = strlen(fname);
+      if (len < 6 || strcmp(fname + len - 5, ".epub") != 0) {
+        bookFile = authorDir.openNextFile();
+        continue;
+      }
+
+      int workId = 0;
+      if (sscanf(fname, "%d_", &workId) != 1 || workId <= 0) {
+        bookFile = authorDir.openNextFile();
+        continue;
+      }
+
+      const char* titleStart = strchr(fname, '_');
+      if (!titleStart) {
+        bookFile = authorDir.openNextFile();
+        continue;
+      }
+      titleStart++;
+      const size_t titleLen = len - (titleStart - fname) - 5;  // ".epub" を除く
+      if (titleLen == 0) {
+        bookFile = authorDir.openNextFile();
+        continue;
+      }
+
+      AozoraBookEntry entry;
+      memset(&entry, 0, sizeof(entry));
+      entry.workId = workId;
+      snprintf(entry.title, sizeof(entry.title), "%.*s", static_cast<int>(titleLen), titleStart);
+      snprintf(entry.author, sizeof(entry.author), "%s", authorName);
+      snprintf(entry.filename, sizeof(entry.filename), "%s/%s", authorName, fname);
+
+      uint32_t offset = 0;
+      if (!appendRecord_(dst, entry, offset)) {
+        LOG_ERR("AOZORA", "rebuild: appendRecord failed");
+        ok = false;
+        break;
+      }
+      rebuiltCount++;
+
+      bookFile = authorDir.openNextFile();
+    }
+    authorDir.close();
+    if (!ok) break;
+    authorDir = rootDir.openNextFile();
+  }
+  rootDir.close();
+  dst.close();
+
+  if (!ok) {
+    Storage.remove(INDEX_TMP_PATH);
+    return false;
+  }
+
+  if (!Storage.rename(INDEX_TMP_PATH, INDEX_BIN_PATH)) {
+    LOG_ERR("AOZORA", "rebuild: rename failed");
+    Storage.remove(INDEX_TMP_PATH);
+    return false;
+  }
+
+  LOG_DBG("AOZORA", "Rebuilt %d entries from directory scan", rebuiltCount);
   return true;
 }
 

--- a/src/AozoraIndexManager.cpp
+++ b/src/AozoraIndexManager.cpp
@@ -1,112 +1,203 @@
 #include "AozoraIndexManager.h"
 
-#include <ArduinoJson.h>
 #include <Logging.h>
 
+#include <algorithm>
 #include <cstring>
 
 constexpr uint8_t AozoraIndexManager::BIN_HEADER_MAGIC[4];
 
 bool AozoraIndexManager::loadAndPurge() {
-  entries_.clear();
+  downloadedIds_.clear();
+  activeOffsets_.clear();
 
-  FsFile file;
-  if (!Storage.openFileForRead("AOZORA", INDEX_PATH, file)) {
-    LOG_DBG("AOZORA", "No index file, starting fresh");
-    return true;
+  if (Storage.exists(INDEX_BIN_PATH)) {
+    return loadFromBin_();
   }
 
-  JsonDocument doc;
-  DeserializationError err = deserializeJson(doc, file);
-  file.close();
-
-  if (err) {
-    LOG_ERR("AOZORA", "Index parse error: %s", err.c_str());
-    return true;
-  }
-
-  JsonArray arr = doc.as<JsonArray>();
-  entries_.reserve(arr.size());
-
-  bool needsSave = false;
-  for (JsonObject obj : arr) {
-    AozoraBookEntry entry;
-    entry.workId = obj["work_id"] | 0;
-    snprintf(entry.title, sizeof(entry.title), "%s", (const char*)(obj["title"] | ""));
-    snprintf(entry.author, sizeof(entry.author), "%s", (const char*)(obj["author"] | ""));
-    snprintf(entry.filename, sizeof(entry.filename), "%s", (const char*)(obj["filename"] | ""));
-
-    char fullPath[160];
-    snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, entry.filename);
-
-    if (Storage.exists(fullPath)) {
-      entries_.push_back(entry);
-    } else {
-      LOG_DBG("AOZORA", "Purging missing: %s", entry.filename);
-      needsSave = true;
-    }
-  }
-
-  if (needsSave) {
-    saveIndex();
-  }
-
+  LOG_DBG("AOZORA", "No index bin found, starting fresh");
   return true;
 }
 
-bool AozoraIndexManager::isDownloaded(int workId) const {
-  for (const auto& e : entries_) {
-    if (e.workId == workId) return true;
-  }
-  return false;
+bool AozoraIndexManager::isDownloaded(int32_t workId) const {
+  return std::binary_search(downloadedIds_.begin(), downloadedIds_.end(), workId);
 }
 
-bool AozoraIndexManager::addEntry(int workId, const char* title, const char* author, const char* filename) {
+bool AozoraIndexManager::addEntry(int32_t workId, const char* title, const char* author, const char* filename) {
   if (isDownloaded(workId)) return true;
 
   AozoraBookEntry entry;
+  memset(&entry, 0, sizeof(entry));
   entry.workId = workId;
   snprintf(entry.title, sizeof(entry.title), "%s", title);
   snprintf(entry.author, sizeof(entry.author), "%s", author);
   snprintf(entry.filename, sizeof(entry.filename), "%s", filename);
-  entries_.push_back(entry);
 
-  return saveIndex();
-}
-
-bool AozoraIndexManager::removeEntry(int workId) {
-  for (auto it = entries_.begin(); it != entries_.end(); ++it) {
-    if (it->workId == workId) {
-      char fullPath[160];
-      snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, it->filename);
-      Storage.remove(fullPath);
-      entries_.erase(it);
-      return saveIndex();
-    }
-  }
-  return false;
-}
-
-bool AozoraIndexManager::saveIndex() const {
-  JsonDocument doc;
-  JsonArray arr = doc.to<JsonArray>();
-
-  for (const auto& e : entries_) {
-    JsonObject obj = arr.add<JsonObject>();
-    obj["work_id"] = e.workId;
-    obj["title"] = e.title;
-    obj["author"] = e.author;
-    obj["filename"] = e.filename;
-  }
-
-  FsFile file;
-  if (!Storage.openFileForWrite("AOZORA", INDEX_PATH, file)) {
-    LOG_ERR("AOZORA", "Failed to open index for write");
+  HalFile file;
+  const bool binExists = Storage.exists(INDEX_BIN_PATH);
+  if (!Storage.openFileForWrite("AOZORA", INDEX_BIN_PATH, file)) {
+    LOG_ERR("AOZORA", "addEntry: open bin for write failed");
     return false;
   }
 
-  serializeJson(doc, file);
+  if (!binExists) {
+    if (!writeHeader_(file)) {
+      file.close();
+      Storage.remove(INDEX_BIN_PATH);
+      return false;
+    }
+  }
+
+  uint32_t offset = 0;
+  if (!appendRecord_(file, entry, offset)) {
+    file.close();
+    return false;
+  }
   file.close();
+
+  auto it = std::lower_bound(downloadedIds_.begin(), downloadedIds_.end(), workId);
+  downloadedIds_.insert(it, workId);
+  activeOffsets_.push_back(offset);
+  return true;
+}
+
+bool AozoraIndexManager::removeEntry(int32_t workId) {
+  auto idIt = std::lower_bound(downloadedIds_.begin(), downloadedIds_.end(), workId);
+  if (idIt == downloadedIds_.end() || *idIt != workId) return false;
+
+  // activeOffsets_ から該当エントリを見つけて、bin ファイルの実ファイルパスを取得し
+  // tombstone を書き込む。実ファイル削除もこの過程で行う。
+  HalFile file;
+  if (!Storage.openFileForWrite("AOZORA", INDEX_BIN_PATH, file)) {
+    LOG_ERR("AOZORA", "removeEntry: open bin failed");
+    return false;
+  }
+
+  bool found = false;
+  size_t foundIndex = 0;
+  for (size_t i = 0; i < activeOffsets_.size(); ++i) {
+    const uint32_t offset = activeOffsets_[i];
+    if (!file.seekSet(offset + 1)) continue;  // status バイトを飛ばして workId を読む
+    int32_t recWorkId = 0;
+    if (file.read(&recWorkId, sizeof(recWorkId)) != static_cast<int>(sizeof(recWorkId))) continue;
+    if (recWorkId != workId) continue;
+
+    // filename を読み出して SD から削除
+    AozoraBookEntry entry;
+    memset(&entry, 0, sizeof(entry));
+    if (!file.seekSet(offset + 1)) {
+      file.close();
+      return false;
+    }
+    if (file.read(&entry, sizeof(entry)) != static_cast<int>(sizeof(entry))) {
+      file.close();
+      return false;
+    }
+
+    if (!markTombstone_(file, offset)) {
+      file.close();
+      return false;
+    }
+
+    char fullPath[160];
+    snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, entry.filename);
+    Storage.remove(fullPath);
+
+    found = true;
+    foundIndex = i;
+    break;
+  }
+  file.close();
+
+  if (!found) {
+    LOG_ERR("AOZORA", "removeEntry: workId %d not found in bin", workId);
+    return false;
+  }
+
+  downloadedIds_.erase(idIt);
+  activeOffsets_.erase(activeOffsets_.begin() + foundIndex);
+  return true;
+}
+
+bool AozoraIndexManager::readEntryAt(size_t indexInActive, AozoraBookEntry& out) const {
+  if (indexInActive >= activeOffsets_.size()) return false;
+  const uint32_t offset = activeOffsets_[indexInActive];
+
+  HalFile file;
+  if (!Storage.openFileForRead("AOZORA", INDEX_BIN_PATH, file)) {
+    LOG_ERR("AOZORA", "readEntryAt: open bin failed");
+    return false;
+  }
+  if (!file.seekSet(offset + 1)) {  // status バイトを飛ばす
+    file.close();
+    return false;
+  }
+  const int bytes = file.read(&out, sizeof(out));
+  file.close();
+  if (bytes != static_cast<int>(sizeof(out))) {
+    LOG_ERR("AOZORA", "readEntryAt: short read at offset %u", offset);
+    return false;
+  }
+  return true;
+}
+
+bool AozoraIndexManager::loadFromBin_() {
+  HalFile file;
+  if (!Storage.openFileForRead("AOZORA", INDEX_BIN_PATH, file)) {
+    LOG_ERR("AOZORA", "loadFromBin: open failed");
+    return false;
+  }
+
+  if (!checkHeader_(file)) {
+    LOG_ERR("AOZORA", "loadFromBin: header invalid");
+    file.close();
+    return false;
+  }
+
+  const size_t fileSize = file.fileSize();
+  if (fileSize < BIN_HEADER_SIZE) {
+    file.close();
+    return true;  // 空のインデックス
+  }
+
+  const size_t estimatedCount = (fileSize - BIN_HEADER_SIZE) / BIN_RECORD_SIZE;
+  downloadedIds_.reserve(estimatedCount);
+  activeOffsets_.reserve(estimatedCount);
+
+  // 全レコードを走査。tombstone はスキップ、実ファイル欠損は tombstone マーク。
+  size_t offset = BIN_HEADER_SIZE;
+  while (offset + BIN_RECORD_SIZE <= fileSize) {
+    if (!file.seekSet(offset)) break;
+
+    uint8_t status = 0;
+    if (file.read(&status, 1) != 1) break;
+
+    if (status != STATUS_ACTIVE) {
+      offset += BIN_RECORD_SIZE;
+      continue;
+    }
+
+    AozoraBookEntry entry;
+    memset(&entry, 0, sizeof(entry));
+    if (file.read(&entry, sizeof(entry)) != static_cast<int>(sizeof(entry))) break;
+
+    // 実ファイル存在チェック
+    char fullPath[160];
+    snprintf(fullPath, sizeof(fullPath), "%s/%s", AOZORA_DIR, entry.filename);
+    if (Storage.exists(fullPath)) {
+      auto it = std::lower_bound(downloadedIds_.begin(), downloadedIds_.end(), entry.workId);
+      downloadedIds_.insert(it, entry.workId);
+      activeOffsets_.push_back(static_cast<uint32_t>(offset));
+    } else {
+      LOG_DBG("AOZORA", "Purging missing: %s", entry.filename);
+      markTombstone_(file, static_cast<uint32_t>(offset));
+    }
+
+    offset += BIN_RECORD_SIZE;
+  }
+
+  file.close();
+  LOG_DBG("AOZORA", "Loaded %zu active entries from bin", activeOffsets_.size());
   return true;
 }
 

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -70,6 +70,7 @@ class AozoraIndexManager {
 
   bool loadFromBin_();
   bool migrateFromJson_();
+  bool rebuildFromDirectoryScan_();
 
   // バイナリ形式 I/O ヘルパ
   static bool writeHeader_(HalFile& file);

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -69,6 +69,7 @@ class AozoraIndexManager {
   std::vector<uint32_t> activeOffsets_;  // 挿入順で bin ファイル内のバイトオフセット
 
   bool loadFromBin_();
+  bool migrateFromJson_();
 
   // バイナリ形式 I/O ヘルパ
   static bool writeHeader_(HalFile& file);

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <HalStorage.h>
-
+#include <cstddef>
 #include <cstdint>
-#include <string>
 #include <vector>
+
+class HalFile;
 
 struct AozoraBookEntry {
   int32_t workId;

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -2,20 +2,32 @@
 
 #include <HalStorage.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
 struct AozoraBookEntry {
-  int workId;
+  int32_t workId;
   char title[64];
   char author[32];
   char filename[80];
 };
+static_assert(sizeof(AozoraBookEntry) == 180, "AozoraBookEntry のレイアウトはディスク形式と一致する必要がある");
 
 class AozoraIndexManager {
  public:
   static constexpr const char* AOZORA_DIR = "/Aozora";
   static constexpr const char* INDEX_PATH = "/Aozora/.aozora_index.json";
+  static constexpr const char* INDEX_BIN_PATH = "/Aozora/.aozora_index.bin";
+  static constexpr const char* INDEX_TMP_PATH = "/Aozora/.aozora_index.bin.tmp";
+
+  static constexpr uint8_t STATUS_ACTIVE = 0xA5;
+  static constexpr uint8_t STATUS_TOMBSTONE = 0x00;
+
+  static constexpr uint8_t BIN_HEADER_MAGIC[4] = {'A', 'Z', 'B', 'I'};
+  static constexpr uint8_t BIN_HEADER_VERSION = 0x01;
+  static constexpr size_t BIN_HEADER_SIZE = 8;    // magic(4) + version(1) + reserved(3)
+  static constexpr size_t BIN_RECORD_SIZE = 181;  // status(1) + entry(180)
 
   bool loadAndPurge();
   bool isDownloaded(int workId) const;
@@ -31,4 +43,10 @@ class AozoraIndexManager {
  private:
   std::vector<AozoraBookEntry> entries_;
   bool saveIndex() const;
+
+  // バイナリ形式 I/O ヘルパ（次コミットで呼び出しを追加する）
+  static bool writeHeader_(HalFile& file);
+  static bool checkHeader_(HalFile& file);
+  static bool appendRecord_(HalFile& file, const AozoraBookEntry& entry, uint32_t& outOffset);
+  static bool markTombstone_(HalFile& file, uint32_t offset);
 };

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -14,10 +14,19 @@ struct AozoraBookEntry {
 };
 static_assert(sizeof(AozoraBookEntry) == 180, "AozoraBookEntry のレイアウトはディスク形式と一致する必要がある");
 
+/**
+ * 青空文庫のダウンロード履歴を管理する。
+ *
+ * SD 上の /Aozora/.aozora_index.bin に append-only の固定長バイナリレコードで保存し、
+ * メモリ上には workId のソート済み配列のみを保持する。詳細（title/author）は
+ * 表示時にファイルからページ単位で読み出す。
+ *
+ * これにより 500 件以上の履歴でもヒープ断片化によるクラッシュを回避する。
+ */
 class AozoraIndexManager {
  public:
   static constexpr const char* AOZORA_DIR = "/Aozora";
-  static constexpr const char* INDEX_PATH = "/Aozora/.aozora_index.json";
+  static constexpr const char* INDEX_PATH = "/Aozora/.aozora_index.json";  // 旧形式（マイグレ用）
   static constexpr const char* INDEX_BIN_PATH = "/Aozora/.aozora_index.bin";
   static constexpr const char* INDEX_TMP_PATH = "/Aozora/.aozora_index.bin.tmp";
 
@@ -30,10 +39,25 @@ class AozoraIndexManager {
   static constexpr size_t BIN_RECORD_SIZE = 181;  // status(1) + entry(180)
 
   bool loadAndPurge();
-  bool isDownloaded(int workId) const;
-  bool addEntry(int workId, const char* title, const char* author, const char* filename);
-  bool removeEntry(int workId);
-  const std::vector<AozoraBookEntry>& entries() const { return entries_; }
+
+  /** O(log N) の workId 検索 */
+  bool isDownloaded(int32_t workId) const;
+
+  /** append-only 書き込み + ソート済み配列への挿入 */
+  bool addEntry(int32_t workId, const char* title, const char* author, const char* filename);
+
+  /** tombstone マークで無効化 + SD 上の EPUB ファイルを削除 */
+  bool removeEntry(int32_t workId);
+
+  /** アクティブなエントリの件数（tombstone を除く） */
+  size_t activeCount() const { return activeOffsets_.size(); }
+
+  /**
+   * アクティブなエントリを挿入順で読み出す。indexInActive は [0, activeCount()) の範囲。
+   * 呼び出し側は out に対する所有権を持つ（内部でヒープを保持しない）。
+   */
+  bool readEntryAt(size_t indexInActive, AozoraBookEntry& out) const;
+
   /** 著者名/workId_タイトル.epub 形式の相対パスを生成 */
   static std::string makeRelativePath(int workId, const char* title, const char* author);
   static bool ensureDirectory();
@@ -41,10 +65,12 @@ class AozoraIndexManager {
   static bool ensureAuthorDirectory(const char* author);
 
  private:
-  std::vector<AozoraBookEntry> entries_;
-  bool saveIndex() const;
+  std::vector<int32_t> downloadedIds_;   // ソート済み workId
+  std::vector<uint32_t> activeOffsets_;  // 挿入順で bin ファイル内のバイトオフセット
 
-  // バイナリ形式 I/O ヘルパ（次コミットで呼び出しを追加する）
+  bool loadFromBin_();
+
+  // バイナリ形式 I/O ヘルパ
   static bool writeHeader_(HalFile& file);
   static bool checkHeader_(HalFile& file);
   static bool appendRecord_(HalFile& file, const AozoraBookEntry& entry, uint32_t& outOffset);

--- a/src/AozoraIndexManager.h
+++ b/src/AozoraIndexManager.h
@@ -58,8 +58,11 @@ class AozoraIndexManager {
    */
   bool readEntryAt(size_t indexInActive, AozoraBookEntry& out) const;
 
-  /** 著者名/workId_タイトル.epub 形式の相対パスを生成 */
-  static std::string makeRelativePath(int workId, const char* title, const char* author);
+  /**
+   * 著者名/workId_タイトル.epub 形式の相対パスを out に書き込む。
+   * 成功時 true。ホットパスから std::string を排除するため out バッファを受け取る形式。
+   */
+  static bool makeRelativePath(int workId, const char* title, const char* author, char* out, size_t outSize);
   static bool ensureDirectory();
   /** 著者名サブディレクトリを含む保存先を確保 */
   static bool ensureAuthorDirectory(const char* author);

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -330,6 +330,8 @@ bool AozoraActivity::downloadBook() {
   if (!indexManager_.addEntry(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_, relPath.c_str())) {
     LOG_ERR("AOZORA", "Failed to add index entry");
     // File is downloaded but index failed -- not critical
+  } else {
+    invalidateDownloadedPageCache();
   }
 
   LOG_DBG("AOZORA", "Downloaded: %s", destPath);
@@ -785,6 +787,14 @@ void AozoraActivity::loop() {
       // ダウンロード済み: Left = 削除, Right = 更新
       if (mappedInput.wasPressed(MappedInputManager::Button::Left)) {
         if (indexManager_.removeEntry(selectedWorkId_)) {
+          invalidateDownloadedPageCache();
+          // 削除で selectedIndex_ が範囲外になり得る（DOWNLOADED_LIST 経由で来ている場合）
+          const int newTotal = static_cast<int>(indexManager_.activeCount());
+          if (selectedIndex_ >= newTotal && newTotal > 0) {
+            selectedIndex_ = newTotal - 1;
+          } else if (newTotal == 0) {
+            selectedIndex_ = 0;
+          }
           {
             RenderLock lock(*this);
             popState();
@@ -927,10 +937,10 @@ void AozoraActivity::loop() {
       return;
     }
 
-    const auto& entries = indexManager_.entries();
+    const int total = static_cast<int>(indexManager_.activeCount());
 
-    buttonNavigator_.onNextRelease([this, &entries] {
-      if (selectedIndex_ < static_cast<int>(entries.size()) - 1) {
+    buttonNavigator_.onNextRelease([this, total] {
+      if (selectedIndex_ < total - 1) {
         selectedIndex_++;
         requestUpdate();
       }
@@ -944,17 +954,25 @@ void AozoraActivity::loop() {
     });
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      if (!entries.empty() && selectedIndex_ < static_cast<int>(entries.size())) {
-        const auto& entry = entries[selectedIndex_];
-        selectedWorkId_ = entry.workId;
-        snprintf(selectedWorkTitle_, sizeof(selectedWorkTitle_), "%s", entry.title);
-        snprintf(selectedWorkAuthor_, sizeof(selectedWorkAuthor_), "%s", entry.author);
-
-        {
-          RenderLock lock(*this);
-          pushState(WORK_DETAIL);
+      if (total > 0 && selectedIndex_ < total) {
+        // 選択中のエントリがページキャッシュ内にあることを保証してから読む
+        const int pageStart = (selectedIndex_ / DL_PAGE_SIZE) * DL_PAGE_SIZE;
+        if (dlPageStart_ != pageStart) {
+          loadDownloadedPage(pageStart);
         }
-        requestUpdate();
+        const int localIdx = selectedIndex_ - dlPageStart_;
+        if (localIdx >= 0 && localIdx < dlPageCount_) {
+          const auto& entry = dlPageCache_[localIdx];
+          selectedWorkId_ = entry.workId;
+          snprintf(selectedWorkTitle_, sizeof(selectedWorkTitle_), "%s", entry.title);
+          snprintf(selectedWorkAuthor_, sizeof(selectedWorkAuthor_), "%s", entry.author);
+
+          {
+            RenderLock lock(*this);
+            pushState(WORK_DETAIL);
+          }
+          requestUpdate();
+        }
       }
     }
   } else if (state_ == ERROR) {
@@ -1192,19 +1210,35 @@ void AozoraActivity::render(RenderLock&&) {
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   } else if (state_ == DOWNLOADED_LIST) {
-    const auto& entries = indexManager_.entries();
+    const int total = static_cast<int>(indexManager_.activeCount());
 
-    if (entries.empty()) {
+    if (total == 0) {
       renderer.drawCenteredText(UI_10_FONT_ID, centerY, tr(STR_NO_RESULTS));
       const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     } else {
+      // 選択中のエントリを含むページをキャッシュに載せる
+      const int pageStart = (selectedIndex_ / DL_PAGE_SIZE) * DL_PAGE_SIZE;
+      if (dlPageStart_ != pageStart) {
+        loadDownloadedPage(pageStart);
+      }
+
       GUI.drawList(
           renderer,
           Rect{0, contentTop, pageWidth, pageHeight - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing},
-          static_cast<int>(entries.size()), selectedIndex_,
-          [&entries](int index) -> std::string { return entries[index].title; }, nullptr, nullptr,
-          [&entries](int index) -> std::string { return entries[index].author; }, false, nullptr);
+          total, selectedIndex_,
+          [this](int index) -> std::string {
+            const int localIdx = index - dlPageStart_;
+            if (localIdx < 0 || localIdx >= dlPageCount_) return "";
+            return dlPageCache_[localIdx].title;
+          },
+          nullptr, nullptr,
+          [this](int index) -> std::string {
+            const int localIdx = index - dlPageStart_;
+            if (localIdx < 0 || localIdx >= dlPageCount_) return "";
+            return dlPageCache_[localIdx].author;
+          },
+          false, nullptr);
 
       const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
@@ -1220,4 +1254,22 @@ void AozoraActivity::render(RenderLock&&) {
   }
 
   renderer.displayBuffer();
+}
+
+void AozoraActivity::loadDownloadedPage(int start) {
+  const int total = static_cast<int>(indexManager_.activeCount());
+  if (start < 0) start = 0;
+
+  dlPageStart_ = start;
+  dlPageCount_ = 0;
+
+  for (int i = 0; i < DL_PAGE_SIZE; ++i) {
+    const int absIndex = start + i;
+    if (absIndex >= total) break;
+    if (!indexManager_.readEntryAt(absIndex, dlPageCache_[i])) {
+      LOG_ERR("AOZORA", "loadDownloadedPage: readEntryAt(%d) failed", absIndex);
+      break;
+    }
+    dlPageCount_++;
+  }
 }

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -8,6 +8,8 @@
 #include <Logging.h>
 #include <WiFi.h>
 
+#include <algorithm>
+
 #include "MappedInputManager.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
@@ -800,12 +802,18 @@ void AozoraActivity::loop() {
       if (mappedInput.wasPressed(MappedInputManager::Button::Left)) {
         if (indexManager_.removeEntry(selectedWorkId_)) {
           invalidateDownloadedPageCache();
-          // 削除で selectedIndex_ が範囲外になり得る（DOWNLOADED_LIST 経由で来ている場合）
-          const int newTotal = static_cast<int>(indexManager_.activeCount());
-          if (selectedIndex_ >= newTotal && newTotal > 0) {
-            selectedIndex_ = newTotal - 1;
-          } else if (newTotal == 0) {
-            selectedIndex_ = 0;
+          // popState() は selectedIndex_ を selectedIndexStack_.back() で上書きするため、
+          // 親 state が DOWNLOADED_LIST の場合は削除後の件数に合わせてスタック側を
+          // クランプする。他 state（TOP_MENU など）の selectedIndex は履歴件数と無関係
+          // なので触らない。
+          if (!stateStack_.empty() && stateStack_.back() == DOWNLOADED_LIST && !selectedIndexStack_.empty()) {
+            const int newTotal = static_cast<int>(indexManager_.activeCount());
+            int& parentSel = selectedIndexStack_.back();
+            if (newTotal == 0) {
+              parentSel = 0;
+            } else if (parentSel >= newTotal) {
+              parentSel = newTotal - 1;
+            }
           }
           {
             RenderLock lock(*this);
@@ -967,10 +975,9 @@ void AozoraActivity::loop() {
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
       if (total > 0 && selectedIndex_ < total) {
-        // 選択中のエントリがページキャッシュ内にあることを保証してから読む
-        const int pageStart = (selectedIndex_ / DL_PAGE_SIZE) * DL_PAGE_SIZE;
-        if (dlPageStart_ != pageStart) {
-          loadDownloadedPage(pageStart);
+        // 選択中のエントリがキャッシュ範囲外なら selectedIndex_ を中央に置いて再ロードする
+        if (selectedIndex_ < dlPageStart_ || selectedIndex_ >= dlPageStart_ + dlPageCount_) {
+          loadDownloadedPage(selectedIndex_ - DL_PAGE_SIZE / 2);
         }
         const int localIdx = selectedIndex_ - dlPageStart_;
         if (localIdx >= 0 && localIdx < dlPageCount_) {
@@ -1229,10 +1236,12 @@ void AozoraActivity::render(RenderLock&&) {
       const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     } else {
-      // 選択中のエントリを含むページをキャッシュに載せる
-      const int pageStart = (selectedIndex_ / DL_PAGE_SIZE) * DL_PAGE_SIZE;
-      if (dlPageStart_ != pageStart) {
-        loadDownloadedPage(pageStart);
+      // drawList のページサイズは theme と画面高に依存し、DL_PAGE_SIZE と一致しないため、
+      // selectedIndex_ がキャッシュ範囲外に出たら selectedIndex_ を中央に置いて再ロードする。
+      // これにより drawList が要求する [selectedIdx / pageItems * pageItems, +pageItems) の
+      // 範囲は pageItems <= DL_PAGE_SIZE / 2 の限り必ずキャッシュ内に収まる。
+      if (selectedIndex_ < dlPageStart_ || selectedIndex_ >= dlPageStart_ + dlPageCount_) {
+        loadDownloadedPage(selectedIndex_ - DL_PAGE_SIZE / 2);
       }
 
       GUI.drawList(
@@ -1268,9 +1277,20 @@ void AozoraActivity::render(RenderLock&&) {
   renderer.displayBuffer();
 }
 
-void AozoraActivity::loadDownloadedPage(int start) {
+void AozoraActivity::loadDownloadedPage(int desiredStart) {
   const int total = static_cast<int>(indexManager_.activeCount());
+  if (total == 0) {
+    dlPageStart_ = 0;
+    dlPageCount_ = 0;
+    return;
+  }
+
+  // start をリストの末尾側でクランプしてキャッシュサイズを最大化する
+  int start = desiredStart;
   if (start < 0) start = 0;
+  if (start + DL_PAGE_SIZE > total) {
+    start = std::max(0, total - DL_PAGE_SIZE);
+  }
 
   dlPageStart_ = start;
   dlPageCount_ = 0;

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -297,9 +297,15 @@ bool AozoraActivity::downloadBook() {
   char url[256];
   snprintf(url, sizeof(url), "%s/api/convert?work_id=%d", API_BASE, selectedWorkId_);
 
-  std::string relPath = AozoraIndexManager::makeRelativePath(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_);
-  char destPath[160];
-  snprintf(destPath, sizeof(destPath), "%s/%s", AozoraIndexManager::AOZORA_DIR, relPath.c_str());
+  char relPath[160];
+  if (!AozoraIndexManager::makeRelativePath(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_, relPath,
+                                            sizeof(relPath))) {
+    LOG_ERR("AOZORA", "Failed to make relative path");
+    errorMessage_ = "Path error";
+    return false;
+  }
+  char destPath[192];
+  snprintf(destPath, sizeof(destPath), "%s/%s", AozoraIndexManager::AOZORA_DIR, relPath);
 
   if (!AozoraIndexManager::ensureDirectory() || !AozoraIndexManager::ensureAuthorDirectory(selectedWorkAuthor_)) {
     LOG_ERR("AOZORA", "Failed to create directory");
@@ -327,7 +333,7 @@ bool AozoraActivity::downloadBook() {
   }
 
   // Add to index
-  if (!indexManager_.addEntry(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_, relPath.c_str())) {
+  if (!indexManager_.addEntry(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_, relPath)) {
     LOG_ERR("AOZORA", "Failed to add index entry");
     // File is downloaded but index failed -- not critical
   } else {
@@ -342,10 +348,16 @@ bool AozoraActivity::updateBook() {
   char url[256];
   snprintf(url, sizeof(url), "%s/api/convert?work_id=%d", API_BASE, selectedWorkId_);
 
-  std::string relPath = AozoraIndexManager::makeRelativePath(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_);
-  char destPath[160];
-  char tmpPath[168];
-  snprintf(destPath, sizeof(destPath), "%s/%s", AozoraIndexManager::AOZORA_DIR, relPath.c_str());
+  char relPath[160];
+  if (!AozoraIndexManager::makeRelativePath(selectedWorkId_, selectedWorkTitle_, selectedWorkAuthor_, relPath,
+                                            sizeof(relPath))) {
+    LOG_ERR("AOZORA", "Failed to make relative path");
+    errorMessage_ = "Path error";
+    return false;
+  }
+  char destPath[192];
+  char tmpPath[200];
+  snprintf(destPath, sizeof(destPath), "%s/%s", AozoraIndexManager::AOZORA_DIR, relPath);
   snprintf(tmpPath, sizeof(tmpPath), "%s.tmp", destPath);
 
   if (!AozoraIndexManager::ensureDirectory() || !AozoraIndexManager::ensureAuthorDirectory(selectedWorkAuthor_)) {

--- a/src/activities/settings/AozoraActivity.h
+++ b/src/activities/settings/AozoraActivity.h
@@ -97,6 +97,21 @@ class AozoraActivity : public Activity {
   AozoraIndexManager indexManager_;
   FavoriteAuthorsManager favoritesManager_;
 
+  // DOWNLOADED_LIST 表示用のページキャッシュ。
+  // indexManager_ からオンデマンドで読み出し、常駐メモリを最小化する。
+  static constexpr int DL_PAGE_SIZE = 30;
+  AozoraBookEntry dlPageCache_[DL_PAGE_SIZE] = {};
+  int dlPageStart_ = -1;  // -1 = キャッシュ無効
+  int dlPageCount_ = 0;
+
+  // ページキャッシュに [start, start+DL_PAGE_SIZE) 範囲のエントリを読み込む。
+  void loadDownloadedPage(int start);
+  // 追加・削除でキャッシュを無効化。次の描画で自動的に再ロードされる。
+  void invalidateDownloadedPageCache() {
+    dlPageStart_ = -1;
+    dlPageCount_ = 0;
+  }
+
   // AUTHOR_ACTION state
   int actionMenuIndex_ = 0;
 

--- a/test/aozora_index/AozoraIndexTest.cpp
+++ b/test/aozora_index/AozoraIndexTest.cpp
@@ -1,0 +1,388 @@
+// 青空文庫ダウンロード履歴のバイナリ形式契約テスト。
+//
+// AozoraIndexManager は SD I/O と ArduinoJson に依存するためホストで直接動かせないが、
+// バイナリファイルフォーマット (Header + 181B レコード) の raw byte 契約と、
+// 構造体レイアウトは HalStorage / ArduinoJson 非依存で検証できる。
+//
+// このテストが壊れる = ディスク上のファイルフォーマットが変わり互換性が壊れる、
+// または既存の実機データが読めなくなることを意味する。契約が変わる場合は
+// BIN_HEADER_VERSION をインクリメントし、互換ロジックを追加すること。
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "src/AozoraIndexManager.h"
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_EQ(a, b)                                                                              \
+  do {                                                                                               \
+    if ((a) != (b)) {                                                                                \
+      fprintf(stderr, "  FAIL: %s:%d: (%s) == %ld, expected %ld\n", __FILE__, __LINE__, #a,          \
+              static_cast<long>(a), static_cast<long>(b));                                           \
+      testsFailed++;                                                                                 \
+      return;                                                                                        \
+    }                                                                                                \
+  } while (0)
+
+#define ASSERT_EQ_U(a, b)                                                                            \
+  do {                                                                                               \
+    if ((a) != (b)) {                                                                                \
+      fprintf(stderr, "  FAIL: %s:%d: (%s) == %lu, expected %lu\n", __FILE__, __LINE__, #a,          \
+              static_cast<unsigned long>(a), static_cast<unsigned long>(b));                         \
+      testsFailed++;                                                                                 \
+      return;                                                                                        \
+    }                                                                                                \
+  } while (0)
+
+#define ASSERT_TRUE(cond)                                                \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      testsFailed++;                                                     \
+      return;                                                            \
+    }                                                                    \
+  } while (0)
+
+#define PASS() testsPassed++
+
+// ============================================================================
+// 1. AozoraBookEntry 構造体レイアウトの契約
+// ============================================================================
+
+static void test_entry_layout_size() {
+  ASSERT_EQ_U(sizeof(AozoraBookEntry), 180u);
+  PASS();
+}
+
+static void test_entry_field_offsets() {
+  // オフセットが変わるとバイナリ形式が壊れる
+  ASSERT_EQ_U(offsetof(AozoraBookEntry, workId), 0u);
+  ASSERT_EQ_U(offsetof(AozoraBookEntry, title), 4u);
+  ASSERT_EQ_U(offsetof(AozoraBookEntry, author), 68u);
+  ASSERT_EQ_U(offsetof(AozoraBookEntry, filename), 100u);
+  PASS();
+}
+
+static void test_entry_field_sizes() {
+  AozoraBookEntry e{};
+  ASSERT_EQ_U(sizeof(e.workId), 4u);
+  ASSERT_EQ_U(sizeof(e.title), 64u);
+  ASSERT_EQ_U(sizeof(e.author), 32u);
+  ASSERT_EQ_U(sizeof(e.filename), 80u);
+  PASS();
+}
+
+// ============================================================================
+// 2. Header / Record サイズ定数
+// ============================================================================
+
+static void test_header_size() {
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_SIZE, 8u);
+  PASS();
+}
+
+static void test_record_size() {
+  // レコードは status(1) + entry(180) = 181
+  ASSERT_EQ_U(AozoraIndexManager::BIN_RECORD_SIZE, 1u + sizeof(AozoraBookEntry));
+  ASSERT_EQ_U(AozoraIndexManager::BIN_RECORD_SIZE, 181u);
+  PASS();
+}
+
+static void test_status_bytes() {
+  // status バイトは 0xA5 / 0x00 で、初期化された領域が誤って ACTIVE と誤認されない
+  ASSERT_EQ_U(AozoraIndexManager::STATUS_ACTIVE, 0xA5u);
+  ASSERT_EQ_U(AozoraIndexManager::STATUS_TOMBSTONE, 0x00u);
+  // 0xFF (フラッシュのデフォルト値) と 0x00 (memset ゼロ) が両方 ACTIVE と衝突しないこと
+  ASSERT_TRUE(AozoraIndexManager::STATUS_ACTIVE != 0xFFu);
+  ASSERT_TRUE(AozoraIndexManager::STATUS_ACTIVE != 0x00u);
+  PASS();
+}
+
+static void test_header_magic() {
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_MAGIC[0], 'A');
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_MAGIC[1], 'Z');
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_MAGIC[2], 'B');
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_MAGIC[3], 'I');
+  ASSERT_EQ_U(AozoraIndexManager::BIN_HEADER_VERSION, 0x01u);
+  PASS();
+}
+
+// ============================================================================
+// 3. パス定数
+// ============================================================================
+
+static void test_path_constants() {
+  ASSERT_TRUE(strcmp(AozoraIndexManager::AOZORA_DIR, "/Aozora") == 0);
+  ASSERT_TRUE(strcmp(AozoraIndexManager::INDEX_PATH, "/Aozora/.aozora_index.json") == 0);
+  ASSERT_TRUE(strcmp(AozoraIndexManager::INDEX_BIN_PATH, "/Aozora/.aozora_index.bin") == 0);
+  ASSERT_TRUE(strcmp(AozoraIndexManager::INDEX_TMP_PATH, "/Aozora/.aozora_index.bin.tmp") == 0);
+  PASS();
+}
+
+// ============================================================================
+// 4. int32_t のリトルエンディアン書き込み
+// ESP32-C3 (RISC-V) はリトルエンディアン。バイナリの int32_t は memcpy で読み書きされる想定。
+// ============================================================================
+
+static void test_little_endian_workId_roundtrip() {
+  AozoraBookEntry e{};
+  e.workId = 0x12345678;
+  snprintf(e.title, sizeof(e.title), "roundtrip");
+
+  // struct を一度メモリバッファに書き出し、リトルエンディアンで戻せることを確認
+  uint8_t buf[sizeof(AozoraBookEntry)];
+  memcpy(buf, &e, sizeof(e));
+
+  // workId のバイトオフセットは 0-3、リトルエンディアン
+  ASSERT_EQ_U(buf[0], 0x78u);
+  ASSERT_EQ_U(buf[1], 0x56u);
+  ASSERT_EQ_U(buf[2], 0x34u);
+  ASSERT_EQ_U(buf[3], 0x12u);
+
+  // 逆方向
+  AozoraBookEntry back{};
+  memcpy(&back, buf, sizeof(back));
+  ASSERT_EQ(back.workId, 0x12345678);
+  ASSERT_TRUE(strcmp(back.title, "roundtrip") == 0);
+  PASS();
+}
+
+// ============================================================================
+// 5. ページキャッシュの境界計算
+// AozoraActivity::loadDownloadedPage で使う selectedIndex → pageStart の算出は
+// (selectedIndex_ / DL_PAGE_SIZE) * DL_PAGE_SIZE。エッジケースを検証する。
+// ============================================================================
+
+static int pageStartFor(int selectedIndex) {
+  constexpr int DL_PAGE_SIZE = 30;
+  if (selectedIndex < 0) return 0;
+  return (selectedIndex / DL_PAGE_SIZE) * DL_PAGE_SIZE;
+}
+
+static void test_page_boundary_calculation() {
+  ASSERT_EQ(pageStartFor(0), 0);
+  ASSERT_EQ(pageStartFor(1), 0);
+  ASSERT_EQ(pageStartFor(29), 0);
+  ASSERT_EQ(pageStartFor(30), 30);
+  ASSERT_EQ(pageStartFor(31), 30);
+  ASSERT_EQ(pageStartFor(59), 30);
+  ASSERT_EQ(pageStartFor(60), 60);
+  ASSERT_EQ(pageStartFor(1000), 990);  // 1000 / 30 = 33, 33 * 30 = 990
+  PASS();
+}
+
+// ============================================================================
+// 6. sorted vector<int32_t> による isDownloaded の O(log N) 検索契約
+// ============================================================================
+
+static void test_sorted_workid_binary_search() {
+  std::vector<int32_t> ids;
+  const int32_t testIds[] = {5, 10, 15, 20, 25, 30, 100, 500, 1000, 99999};
+  for (int32_t id : testIds) {
+    auto it = std::lower_bound(ids.begin(), ids.end(), id);
+    ids.insert(it, id);
+  }
+  // insert がソート順を維持している
+  ASSERT_TRUE(std::is_sorted(ids.begin(), ids.end()));
+
+  for (int32_t id : testIds) {
+    ASSERT_TRUE(std::binary_search(ids.begin(), ids.end(), id));
+  }
+  ASSERT_TRUE(!std::binary_search(ids.begin(), ids.end(), 0));
+  ASSERT_TRUE(!std::binary_search(ids.begin(), ids.end(), 6));
+  ASSERT_TRUE(!std::binary_search(ids.begin(), ids.end(), 1000000));
+
+  // 挿入順 (100 が末尾に来る) でも sorted 順を維持
+  {
+    std::vector<int32_t> ids2;
+    const int32_t inputOrder[] = {50, 20, 100, 10, 30, 80};
+    for (int32_t id : inputOrder) {
+      auto it = std::lower_bound(ids2.begin(), ids2.end(), id);
+      ids2.insert(it, id);
+    }
+    ASSERT_TRUE(std::is_sorted(ids2.begin(), ids2.end()));
+    ASSERT_EQ(ids2[0], 10);
+    ASSERT_EQ(ids2[1], 20);
+    ASSERT_EQ(ids2[2], 30);
+    ASSERT_EQ(ids2[3], 50);
+    ASSERT_EQ(ids2[4], 80);
+    ASSERT_EQ(ids2[5], 100);
+  }
+  PASS();
+}
+
+// ============================================================================
+// 7. バイナリファイルの実際のバイト列を組み立ててオフセット整合を確認
+// ============================================================================
+
+static void test_bin_layout_construction() {
+  std::vector<uint8_t> file;
+
+  // Header (8B): magic "AZBI" + version 0x01 + reserved 0x00 0x00 0x00
+  file.push_back('A');
+  file.push_back('Z');
+  file.push_back('B');
+  file.push_back('I');
+  file.push_back(0x01);
+  file.push_back(0x00);
+  file.push_back(0x00);
+  file.push_back(0x00);
+  ASSERT_EQ_U(file.size(), AozoraIndexManager::BIN_HEADER_SIZE);
+
+  // 1 レコード目 (181B): status 0xA5 + entry
+  file.push_back(AozoraIndexManager::STATUS_ACTIVE);
+  AozoraBookEntry e1{};
+  e1.workId = 42;
+  snprintf(e1.title, sizeof(e1.title), "sample");
+  snprintf(e1.author, sizeof(e1.author), "author1");
+  snprintf(e1.filename, sizeof(e1.filename), "author1/42_sample.epub");
+  const uint8_t* e1bytes = reinterpret_cast<const uint8_t*>(&e1);
+  file.insert(file.end(), e1bytes, e1bytes + sizeof(e1));
+  ASSERT_EQ_U(file.size(), AozoraIndexManager::BIN_HEADER_SIZE + AozoraIndexManager::BIN_RECORD_SIZE);
+
+  // 2 レコード目 = tombstone (status 0x00 + 何らかの entry)
+  file.push_back(AozoraIndexManager::STATUS_TOMBSTONE);
+  AozoraBookEntry e2{};
+  e2.workId = 99;
+  const uint8_t* e2bytes = reinterpret_cast<const uint8_t*>(&e2);
+  file.insert(file.end(), e2bytes, e2bytes + sizeof(e2));
+
+  // 3 レコード目 = active
+  file.push_back(AozoraIndexManager::STATUS_ACTIVE);
+  AozoraBookEntry e3{};
+  e3.workId = 200;
+  snprintf(e3.title, sizeof(e3.title), "third");
+  snprintf(e3.author, sizeof(e3.author), "authorN");
+  snprintf(e3.filename, sizeof(e3.filename), "authorN/200_third.epub");
+  const uint8_t* e3bytes = reinterpret_cast<const uint8_t*>(&e3);
+  file.insert(file.end(), e3bytes, e3bytes + sizeof(e3));
+
+  // 各レコードのオフセットが式通り (HEADER + i * RECORD_SIZE) に配置されている
+  const size_t rec1Offset = AozoraIndexManager::BIN_HEADER_SIZE;
+  const size_t rec2Offset = AozoraIndexManager::BIN_HEADER_SIZE + AozoraIndexManager::BIN_RECORD_SIZE;
+  const size_t rec3Offset = AozoraIndexManager::BIN_HEADER_SIZE + 2 * AozoraIndexManager::BIN_RECORD_SIZE;
+
+  ASSERT_EQ_U(file[rec1Offset], AozoraIndexManager::STATUS_ACTIVE);
+  ASSERT_EQ_U(file[rec2Offset], AozoraIndexManager::STATUS_TOMBSTONE);
+  ASSERT_EQ_U(file[rec3Offset], AozoraIndexManager::STATUS_ACTIVE);
+
+  // Record 1 の workId (offset + 1、リトルエンディアン)
+  ASSERT_EQ_U(file[rec1Offset + 1], 42u);
+  ASSERT_EQ_U(file[rec1Offset + 2], 0u);
+  ASSERT_EQ_U(file[rec1Offset + 3], 0u);
+  ASSERT_EQ_U(file[rec1Offset + 4], 0u);
+
+  // Record 3 の workId (200 = 0xC8)
+  ASSERT_EQ_U(file[rec3Offset + 1], 0xC8u);
+  ASSERT_EQ_U(file[rec3Offset + 2], 0u);
+
+  // 想定通りの loadFromBin_ の走査: HEADER から RECORD_SIZE 刻みで active のみ拾う
+  std::vector<size_t> activeOffsets;
+  size_t offset = AozoraIndexManager::BIN_HEADER_SIZE;
+  while (offset + AozoraIndexManager::BIN_RECORD_SIZE <= file.size()) {
+    if (file[offset] == AozoraIndexManager::STATUS_ACTIVE) {
+      activeOffsets.push_back(offset);
+    }
+    offset += AozoraIndexManager::BIN_RECORD_SIZE;
+  }
+  ASSERT_EQ_U(activeOffsets.size(), 2u);
+  ASSERT_EQ_U(activeOffsets[0], rec1Offset);
+  ASSERT_EQ_U(activeOffsets[1], rec3Offset);
+  PASS();
+}
+
+// ============================================================================
+// 8. tombstone マーキング後、ファイルサイズは変わらないという契約
+// ============================================================================
+
+static void test_tombstone_preserves_record_positions() {
+  std::vector<uint8_t> file(AozoraIndexManager::BIN_HEADER_SIZE + 3 * AozoraIndexManager::BIN_RECORD_SIZE);
+  memset(file.data(), 0, file.size());
+
+  // すべて ACTIVE にする
+  file[AozoraIndexManager::BIN_HEADER_SIZE] = AozoraIndexManager::STATUS_ACTIVE;
+  file[AozoraIndexManager::BIN_HEADER_SIZE + AozoraIndexManager::BIN_RECORD_SIZE] = AozoraIndexManager::STATUS_ACTIVE;
+  file[AozoraIndexManager::BIN_HEADER_SIZE + 2 * AozoraIndexManager::BIN_RECORD_SIZE] =
+      AozoraIndexManager::STATUS_ACTIVE;
+
+  const size_t sizeBefore = file.size();
+
+  // 中央のレコードを tombstone にする (実装と同じく status バイトのみ書き換え)
+  file[AozoraIndexManager::BIN_HEADER_SIZE + AozoraIndexManager::BIN_RECORD_SIZE] =
+      AozoraIndexManager::STATUS_TOMBSTONE;
+
+  ASSERT_EQ_U(file.size(), sizeBefore);  // サイズ不変
+  // 前後のオフセットは維持されている
+  ASSERT_EQ_U(file[AozoraIndexManager::BIN_HEADER_SIZE], AozoraIndexManager::STATUS_ACTIVE);
+  ASSERT_EQ_U(file[AozoraIndexManager::BIN_HEADER_SIZE + 2 * AozoraIndexManager::BIN_RECORD_SIZE],
+              AozoraIndexManager::STATUS_ACTIVE);
+  PASS();
+}
+
+// ============================================================================
+// 9. workId=0 の扱い
+// rebuildFromDirectoryScan_ で sscanf が失敗した場合 workId=0 は無効と判定する仕様
+// ============================================================================
+
+static void test_workid_zero_is_invalid_marker() {
+  // sscanf(fname, "%d_", &workId) が失敗すれば workId は書き換えられず初期値 0 のまま。
+  // 実装は「workId <= 0 ならスキップ」なので、0 を無効値としてマーカーに使える。
+  int workId = 0;
+  int matched = sscanf("garbage_name.epub", "%d_", &workId);
+  ASSERT_EQ(matched, 0);
+  ASSERT_EQ(workId, 0);
+
+  workId = 0;
+  matched = sscanf("42_title.epub", "%d_", &workId);
+  ASSERT_EQ(matched, 1);
+  ASSERT_EQ(workId, 42);
+  PASS();
+}
+
+// ============================================================================
+// テストランナー
+// ============================================================================
+
+typedef void (*TestFn)();
+
+struct TestCase {
+  const char* name;
+  TestFn fn;
+};
+
+int main() {
+  const TestCase tests[] = {
+      {"entry_layout_size", test_entry_layout_size},
+      {"entry_field_offsets", test_entry_field_offsets},
+      {"entry_field_sizes", test_entry_field_sizes},
+      {"header_size", test_header_size},
+      {"record_size", test_record_size},
+      {"status_bytes", test_status_bytes},
+      {"header_magic", test_header_magic},
+      {"path_constants", test_path_constants},
+      {"little_endian_workId_roundtrip", test_little_endian_workId_roundtrip},
+      {"page_boundary_calculation", test_page_boundary_calculation},
+      {"sorted_workid_binary_search", test_sorted_workid_binary_search},
+      {"bin_layout_construction", test_bin_layout_construction},
+      {"tombstone_preserves_record_positions", test_tombstone_preserves_record_positions},
+      {"workid_zero_is_invalid_marker", test_workid_zero_is_invalid_marker},
+  };
+
+  for (const auto& t : tests) {
+    printf("Running %s...\n", t.name);
+    t.fn();
+  }
+
+  printf("\n=== Results ===\n");
+  printf("  Passed: %d\n", testsPassed);
+  printf("  Failed: %d\n", testsFailed);
+
+  return testsFailed == 0 ? 0 : 1;
+}

--- a/test/aozora_index/AozoraIndexTest.cpp
+++ b/test/aozora_index/AozoraIndexTest.cpp
@@ -21,24 +21,24 @@
 static int testsPassed = 0;
 static int testsFailed = 0;
 
-#define ASSERT_EQ(a, b)                                                                              \
-  do {                                                                                               \
-    if ((a) != (b)) {                                                                                \
-      fprintf(stderr, "  FAIL: %s:%d: (%s) == %ld, expected %ld\n", __FILE__, __LINE__, #a,          \
-              static_cast<long>(a), static_cast<long>(b));                                           \
-      testsFailed++;                                                                                 \
-      return;                                                                                        \
-    }                                                                                                \
+#define ASSERT_EQ(a, b)                                                                                           \
+  do {                                                                                                            \
+    if ((a) != (b)) {                                                                                             \
+      fprintf(stderr, "  FAIL: %s:%d: (%s) == %ld, expected %ld\n", __FILE__, __LINE__, #a, static_cast<long>(a), \
+              static_cast<long>(b));                                                                              \
+      testsFailed++;                                                                                              \
+      return;                                                                                                     \
+    }                                                                                                             \
   } while (0)
 
-#define ASSERT_EQ_U(a, b)                                                                            \
-  do {                                                                                               \
-    if ((a) != (b)) {                                                                                \
-      fprintf(stderr, "  FAIL: %s:%d: (%s) == %lu, expected %lu\n", __FILE__, __LINE__, #a,          \
-              static_cast<unsigned long>(a), static_cast<unsigned long>(b));                         \
-      testsFailed++;                                                                                 \
-      return;                                                                                        \
-    }                                                                                                \
+#define ASSERT_EQ_U(a, b)                                                                   \
+  do {                                                                                      \
+    if ((a) != (b)) {                                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: (%s) == %lu, expected %lu\n", __FILE__, __LINE__, #a, \
+              static_cast<unsigned long>(a), static_cast<unsigned long>(b));                \
+      testsFailed++;                                                                        \
+      return;                                                                               \
+    }                                                                                       \
   } while (0)
 
 #define ASSERT_TRUE(cond)                                                \

--- a/test/run_aozora_index_test.sh
+++ b/test/run_aozora_index_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 青空文庫ダウンロード履歴のバイナリ形式契約テストをホスト側で実行する。
+# AozoraIndexManager 本体は SD / ArduinoJson 依存でホストではリンクできないため、
+# ヘッダの契約（struct レイアウト、定数、境界計算）のみを検証する。
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/aozora_index"
+BINARY="$BUILD_DIR/AozoraIndexTest"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/aozora_index/AozoraIndexTest.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$ROOT_DIR"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+"$BINARY" "$@"


### PR DESCRIPTION
## Summary

青空文庫の作品を大量にダウンロードすると、`AozoraIndexManager::loadAndPurge()` が `/Aozora/.aozora_index.json` を `JsonDocument` (ArduinoJson v7) に全件展開し `std::vector<AozoraBookEntry>` に写す時点でヒープ断片化によりクラッシュする問題を解決する。

- **メモリ削減効果 (500件想定)**: 常駐 90KB → 4KB (**22×削減**)、ピーク ~250KB → ~9.4KB (**25×削減**)
- **`isDownloaded()` の計算量**: O(N) 線形探索 → O(log N) `binary_search` (WORK_LIST 描画の 30×線形が 30×log(N) に)
- **既存 JSON からの自動マイグレ + SD 走査 fallback** を実装し、`/Aozora/.aozora_index.json` の破損や消失にも対応

## 設計

`/Aozora/.aozora_index.bin` に append-only の 181B 固定長レコード (status 1B + entry 180B)。常駐メモリは workId のソート済み `vector<int32_t>` と bin 内オフセット `vector<uint32_t>` のみ。詳細 (title/author/filename) は `DOWNLOADED_LIST` 表示時に `AozoraBookEntry pageCache_[30]` へオンデマンド読み出し。

### バイナリ形式

```
[ Header 8B ]  magic="AZBI" + version=0x01 + reserved[3]
[ Record N × 181B ]  status(0xA5 active / 0x00 tombstone) + AozoraBookEntry(180B)
```

削除は tombstone マークで論理削除、SD 上の EPUB は同時に物理削除。`loadFromBin_` で status==ACTIVE かつ実ファイル存在確認したものだけ index に登録。

### ロード時分岐 (loadAndPurge)

1. `.aozora_index.bin.tmp` が残っていれば削除（前回マイグレの残骸掃除）
2. `.aozora_index.bin` があればそれを読む
3. なければ `.aozora_index.json` を1件ずつストリーム変換して bin に移行（atomic swap）
4. どちらも無いか変換失敗なら `/Aozora/著者名/*.epub` を走査してファイル名から workId を抽出して bin を再構築

## テスト結果

### ホスト側単体テスト (test/aozora_index/, 14 assertions, 全通過)

バイナリ形式の契約 (struct レイアウト、ヘッダ magic/version、STATUS 定数、リトルエンディアン roundtrip、ソート済み workId 探索、ページ境界計算、tombstone サイズ不変、workId=0 マーカー) を検証。

実行: `test/run_aozora_index_test.sh`

### 静的解析

`pio check` (cppcheck) — defects 0。

### 実機動作確認 (Xteink X3)

| # | シナリオ | 結果 |
|---|---|---|
| T1 | 既存 JSON (13件) → bin マイグレ | ✅ 成功 |
| T2 | 新規追加 4 件後も既存履歴保持 (17件) | ✅ **O_TRUNC バグ修正の実機検証** |
| T3 | 削除で親 selectedIndex_ が範囲内クランプ | ✅ **H2 修正の実機検証** |
| T4 | bin/JSON 両方削除 → SD 走査で 15 件復元、bin サイズ 2723B (=8+15×181) 完全一致、全レコードの workId/title/author/filename が UTF-8 で正確に復元 | ✅ **rebuildFromDirectoryScan_ の実機検証** |

## Adversarial code review で潰した問題

- **CRITICAL**: `openFileForWrite` の O_TRUNC 挙動により、`addEntry`/`removeEntry` を呼ぶたびに bin 全体が消える → `Storage.open(path, O_RDWR | O_CREAT)` に置換
- **HIGH**: ページキャッシュ境界と drawList の pageItems ミスマッチ → キャッシュ start を selectedIndex 中心のウィンドウに変更
- **HIGH**: 削除後の `selectedIndex_` 書き換えが `popState()` で上書きされて無効 → `selectedIndexStack_.back()` を直接クランプ
- **HIGH**: `loadFromBin_` の O_RDONLY 開きで tombstone マーキングが silent fail → O_RDWR に変更
- **HIGH**: マイグレ失敗時に SD 走査 fallback に落ちない → 破損 JSON 削除 + fallback 実行
- **MEDIUM 3件**: SD 走査バッファサイズ拡大、空 filename/workId=0 防御、readEntryAt の null 終端保証

## 変更対象

- `src/AozoraIndexManager.{h,cpp}` — 主要な実装
- `src/activities/settings/AozoraActivity.{h,cpp}` — DOWNLOADED_LIST 描画・入力をページ読み出しに、削除後のクランプ、makeRelativePath の char[] 化
- `test/aozora_index/AozoraIndexTest.cpp` + `test/run_aozora_index_test.sh` — 新規テスト

## Follow-up 候補（本 PR スコープ外）

- **M1**: `AozoraBookEntry::filename[80]` 拡大 (要 `BIN_HEADER_VERSION` bump)
- **M2**: `readEntryAt` のバッチ化 (現状 30 回 open/close → 1 回に)
- **M3**: `AozoraIndexManager` に内部 mutex を追加して `loop()` と `render()` の race を防ぐ
- **M4**: `FavoriteAuthorsManager` にも同一パターンを適用（現状は件数が少なく問題化していない）

## Test plan

- [x] `pio run -e default` クリーンビルド (0 warnings)
- [x] `test/run_aozora_index_test.sh` (14 assertions 全通過)
- [x] `pio check` (defects 0)
- [x] clang-format 差分ゼロ
- [x] 実機 T1: 既存 JSON からのマイグレ (13件)
- [x] 実機 T2: 新規追加で既存履歴保持 (17件、既存 13件保持)
- [x] 実機 T3: 削除でカーソル位置が正常
- [x] 実機 T4: SD 走査 fallback (15件復元)