### PR TITLE
feat: 青空文庫TXTをブラウザ側でEPUBに変換してからアップロードする機能を追加

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -26,6 +26,7 @@
 #include "html/HomePageHtml.generated.h"
 #include "html/SettingsPageHtml.generated.h"
 #include "html/SleepPageHtml.generated.h"
+#include "html/js/aozora_epubJs.generated.h"
 #include "html/js/jszip_minJs.generated.h"
 
 extern GfxRenderer renderer;
@@ -252,6 +253,7 @@ void CrossPointWebServer::begin() {
   server->on("/", HTTP_GET, [this] { handleRoot(); });
   server->on("/files", HTTP_GET, [this] { handleFileList(); });
   server->on("/js/jszip.min.js", HTTP_GET, [this] { handleJszip(); });
+  server->on("/js/aozora-epub.js", HTTP_GET, [this] { handleAozoraEpubJs(); });
 
   server->on("/api/status", HTTP_GET, [this] { handleStatus(); });
   server->on("/api/files", HTTP_GET, [this] { handleFileListData(); });
@@ -466,6 +468,12 @@ void CrossPointWebServer::handleJszip() const {
   server->sendHeader("Content-Encoding", "gzip");
   server->send_P(200, "application/javascript", jszip_minJs, jszip_minJsCompressedSize);
   LOG_DBG("WEB", "Served jszip.min.js");
+}
+
+void CrossPointWebServer::handleAozoraEpubJs() const {
+  server->sendHeader("Content-Encoding", "gzip");
+  server->send_P(200, "application/javascript", aozora_epubJs, aozora_epubJsCompressedSize);
+  LOG_DBG("WEB", "Served aozora-epub.js");
 }
 
 void CrossPointWebServer::handleNotFound() const {

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -92,6 +92,7 @@ class CrossPointWebServer {
   // Request handlers
   void handleRoot() const;
   void handleJszip() const;
+  void handleAozoraEpubJs() const;
   void handleNotFound() const;
   void handleStatus() const;
   void handleFileList() const;

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1673,7 +1673,7 @@
       <div class="convert-options" id="txtConvertOptions" style="display:none;">
         <div class="convert-row">
           <label class="convert-checkbox">
-            <input type="checkbox" id="txtConvertBeforeUpload" checked onchange="toggleTxtConvertOptions()">
+            <input type="checkbox" id="txtConvertBeforeUpload" onchange="toggleTxtConvertOptions()">
             <span>青空文庫 TXT → EPUB に変換</span>
           </label>
         </div>
@@ -3085,7 +3085,17 @@ function toggleTxtConvertOptions() {
   if (checked) {
     uploadBtn.textContent = 'Convert & Upload';
     uploadBtn.classList.add('optimize');
-  } else {
+    return;
+  }
+  // TXT 変換を OFF にしても、他 (EPUB / XTC) の変換が有効ならボタン表示は 'Convert & Upload' を維持する。
+  const epubOpts = document.getElementById('convertOptions');
+  const xtcOpts = document.getElementById('xtcConvertOptions');
+  const epubEl = document.getElementById('convertBeforeUpload');
+  const xtcEl = document.getElementById('xtcConvertBeforeUpload');
+  const otherActive =
+    (epubOpts && epubOpts.style.display !== 'none' && epubEl && epubEl.checked) ||
+    (xtcOpts && xtcOpts.style.display !== 'none' && xtcEl && xtcEl.checked);
+  if (!otherActive) {
     uploadBtn.textContent = 'Upload';
     uploadBtn.classList.remove('optimize');
   }
@@ -5300,7 +5310,9 @@ function uploadFile() {
       }
 
       // Convert TXT (Aozora format) to EPUB if needed
-      // 変換失敗時は元 TXT をアップロードせずスキップする（デバイス側の TXT レンダリングを避けるため）
+      // 変換失敗時は元 TXT をそのままアップロードするフォールバックに戻す。
+      // EPUB/XTC 変換パスと挙動を統一し、デバイスからファイルが消える驚きを避ける。
+      // (default OFF なので、この分岐に入るのは変換をユーザーが明示的にオンにした時のみ)
       if (needsTxtConversion) {
         progressFill.style.backgroundColor = '#9b59b6';
         progressText.textContent = `Converting TXT→EPUB: ${file.name} (${currentIndex + 1}/${files.length})...`;
@@ -5313,6 +5325,7 @@ function uploadFile() {
           const result = await window.AozoraEpub.convertTxtToEpub(file, (percent) => {
             progressFill.style.width = (percent * 0.5 * 100) + '%';
           });
+          if (operationCancelled) { if (uploadGeneration === myGeneration) restoreAfterCancel(); return; }
 
           file = new File([result.blob], result.name, { type: 'application/epub+zip' });
           progressFill.style.backgroundColor = '#27ae60';
@@ -5321,12 +5334,12 @@ function uploadFile() {
           if (operationCancelled) { if (uploadGeneration === myGeneration) restoreAfterCancel(); return; }
           console.error('TXT→EPUB conversion error:', convError);
           logError(`TXT→EPUB変換失敗: ${convError.message}`);
-          log('TXT ファイルはアップロードされません。', 'warning', 'INFO');
+          log('元のTXTファイルをそのままアップロードします。', 'warning', 'INFO');
           conversionFailed = true;
-          failedFiles.push({ name: file.name, error: convError.message, file: originalFile });
-          currentIndex++;
-          uploadNextFile();
-          return;
+          progressText.textContent = `TXT変換失敗、元ファイルをアップロード: ${file.name}...`;
+          progressFill.style.backgroundColor = '#e67e22';
+          progressFill.style.width = '0%';
+          // file は元のまま (TXT のまま) アップロードに進む
         }
       }
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1679,7 +1679,7 @@
         </div>
         <div class="convert-settings" id="txtConvertSettings">
           <span>📖 縦書き</span>
-          <span>🈁 UTF-8 のみ</span>
+          <span>🈁 UTF-8 / Shift_JIS 自動判別</span>
           <span>🌸 ルビ / 見出し / 改ページ</span>
         </div>
       </div>

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Files - CrossPoint Reader</title>
   <script src="/js/jszip.min.js"></script>
+  <script src="/js/aozora-epub.js"></script>
   <style>
     :root {
       --font-color: #333;
@@ -1668,6 +1669,20 @@
           </label>
         </div>
       </div>
+      <!-- TXT (Aozora format) to EPUB conversion options -->
+      <div class="convert-options" id="txtConvertOptions" style="display:none;">
+        <div class="convert-row">
+          <label class="convert-checkbox">
+            <input type="checkbox" id="txtConvertBeforeUpload" checked onchange="toggleTxtConvertOptions()">
+            <span>青空文庫 TXT → EPUB に変換</span>
+          </label>
+        </div>
+        <div class="convert-settings" id="txtConvertSettings">
+          <span>📖 縦書き</span>
+          <span>🈁 UTF-8 のみ</span>
+          <span>🌸 ルビ / 見出し / 改ページ</span>
+        </div>
+      </div>
       <!-- Sync compatibility warning - outside picker-columns -->
       <div class="convert-warning" id="convertWarning" style="display:none;" role="alert" aria-live="polite">
         ⚠️ Converting will modify files and can break hash‑based sync. ⚠️<br>
@@ -2955,11 +2970,13 @@
     const files = fileInput.files;
     const convertOptions = document.getElementById('convertOptions');
     const xtcConvertOptions = document.getElementById('xtcConvertOptions');
+    const txtConvertOptions = document.getElementById('txtConvertOptions');
     fileInput.classList.toggle('has-files', files.length > 0);
 
     // Detect file types
     const hasEpub = Array.from(files).some(f => f.name.toLowerCase().endsWith('.epub'));
     const hasZip = Array.from(files).some(f => isZipOrCbz(f.name));
+    const hasTxt = Array.from(files).some(f => f.name.toLowerCase().endsWith('.txt'));
 
     // Show/hide convert options based on file types
     if (files.length > 0 && hasEpub) {
@@ -2983,6 +3000,18 @@
       }
     } else {
       xtcConvertOptions.style.display = 'none';
+    }
+
+    // Show/hide TXT→EPUB convert options for .txt files
+    if (files.length > 0 && hasTxt) {
+      txtConvertOptions.style.display = 'block';
+      const txtChecked = document.getElementById('txtConvertBeforeUpload').checked;
+      if (txtChecked && !hasEpub && !hasZip) {
+        uploadBtn.textContent = 'Convert & Upload';
+        uploadBtn.classList.add('optimize');
+      }
+    } else {
+      txtConvertOptions.style.display = 'none';
     }
 
     if (files.length > 0) {
@@ -3040,6 +3069,18 @@ function isZipOrCbz(filename) {
 
 function toggleXtcConvertOptions() {
   const checked = document.getElementById('xtcConvertBeforeUpload').checked;
+  const uploadBtn = document.getElementById('uploadBtn');
+  if (checked) {
+    uploadBtn.textContent = 'Convert & Upload';
+    uploadBtn.classList.add('optimize');
+  } else {
+    uploadBtn.textContent = 'Upload';
+    uploadBtn.classList.remove('optimize');
+  }
+}
+
+function toggleTxtConvertOptions() {
+  const checked = document.getElementById('txtConvertBeforeUpload').checked;
   const uploadBtn = document.getElementById('uploadBtn');
   if (checked) {
     uploadBtn.textContent = 'Convert & Upload';
@@ -5121,11 +5162,15 @@ function uploadFile() {
     const isZip = isZipOrCbz(file.name);
     const xtcConvertEnabled = document.getElementById('xtcConvertBeforeUpload').checked;
     const needsXtcConversion = isZip && xtcConvertEnabled;
+    const isTxt = file.name.toLowerCase().endsWith('.txt');
+    const txtConvertCheckbox = document.getElementById('txtConvertBeforeUpload');
+    const txtConvertEnabled = txtConvertCheckbox ? txtConvertCheckbox.checked : false;
+    const needsTxtConversion = isTxt && txtConvertEnabled;
     let conversionSucceeded = false;
     let conversionFailed = false;  // Track if conversion actually failed
 
     const methodText = useWebSocket ? ' [WS]' : ' [HTTP]';
-    const stageText = (needsConversion || needsXtcConversion) ? 'Converting & uploading' : 'Uploading';
+    const stageText = (needsConversion || needsXtcConversion || needsTxtConversion) ? 'Converting & uploading' : 'Uploading';
     progressText.style.color = '';
     progressText.textContent = `${stageText} ${file.name} (${currentIndex + 1}/${files.length})${methodText}`;
 
@@ -5251,6 +5296,37 @@ function uploadFile() {
           progressText.textContent = `XTC conversion failed, uploading original ${file.name}...`;
           progressFill.style.backgroundColor = '#e67e22';
           progressFill.style.width = '0%';
+        }
+      }
+
+      // Convert TXT (Aozora format) to EPUB if needed
+      // 変換失敗時は元 TXT をアップロードせずスキップする（デバイス側の TXT レンダリングを避けるため）
+      if (needsTxtConversion) {
+        progressFill.style.backgroundColor = '#9b59b6';
+        progressText.textContent = `Converting TXT→EPUB: ${file.name} (${currentIndex + 1}/${files.length})...`;
+        if (!useBatchLog) {
+          clearLog();
+          showLog();
+        }
+
+        try {
+          const result = await window.AozoraEpub.convertTxtToEpub(file, (percent) => {
+            progressFill.style.width = (percent * 0.5 * 100) + '%';
+          });
+
+          file = new File([result.blob], result.name, { type: 'application/epub+zip' });
+          progressFill.style.backgroundColor = '#27ae60';
+          conversionSucceeded = true;
+        } catch (convError) {
+          if (operationCancelled) { if (uploadGeneration === myGeneration) restoreAfterCancel(); return; }
+          console.error('TXT→EPUB conversion error:', convError);
+          logError(`TXT→EPUB変換失敗: ${convError.message}`);
+          log('TXT ファイルはアップロードされません。', 'warning', 'INFO');
+          conversionFailed = true;
+          failedFiles.push({ name: file.name, error: convError.message, file: originalFile });
+          currentIndex++;
+          uploadNextFile();
+          return;
         }
       }
 

--- a/src/network/html/js/aozora-epub.js
+++ b/src/network/html/js/aozora-epub.js
@@ -48,6 +48,8 @@
   }
 
   // 最初の空行までのタイトル/著者ブロックを本文から取り除く
+  // 空行が1つもない場合はタイトル行を認識できないため本文丸ごと保持する
+  // (短編・自作原稿・タイトルブロックを既に剥がしたテキストで内容が消えるのを防ぐ)
   function removeTitleBlock(text) {
     var lines = text.split('\n');
     var firstBlankIndex = -1;
@@ -57,7 +59,7 @@
         break;
       }
     }
-    if (firstBlankIndex === -1) return '';
+    if (firstBlankIndex === -1) return text;
     return lines.slice(firstBlankIndex + 1).join('\n');
   }
 
@@ -78,10 +80,12 @@
         /^［＃([0-9０-９]+)字下げ］(.+)［＃「(.+)」は(大|中|小)見出し］$/
       );
       if (indentHeadingMatch) {
+        // 見出しは可視テキスト (group 2) を採用。注記の quoted text (group 3) は範囲指定でしかなく、
+        // 章番号や補助語がgroup 2 側に含まれるためこちらを保持する。
         nodes.push({
           type: 'heading',
           level: headingLevelFromSize(indentHeadingMatch[4]),
-          children: parseInline(indentHeadingMatch[3]),
+          children: parseInline(indentHeadingMatch[2]),
         });
         continue;
       }
@@ -96,10 +100,15 @@
       }
       var headingMatch = line.match(/^(.*)［＃「(.+)」は(大|中|小)見出し］(.*)$/);
       if (headingMatch) {
+        // 見出しは可視テキスト (group 1 + group 4) を採用。注記の quoted text (group 2) は
+        // 範囲指定でしかなく、章番号などが group 1 側に含まれるため両側を保持する。
+        // 可視テキストが空なら quoted を fallback として使う。
+        var visibleText = headingMatch[1] + headingMatch[4];
+        var headingText = visibleText.trim() !== '' ? visibleText : headingMatch[2];
         nodes.push({
           type: 'heading',
           level: headingLevelFromSize(headingMatch[3]),
-          children: parseInline(headingMatch[2]),
+          children: parseInline(headingText),
         });
         continue;
       }
@@ -141,21 +150,13 @@
       }
       var emphasisMatch = remaining.match(/^［＃「([^」]+)」に傍点］/);
       if (emphasisMatch) {
-        nodes.push({
-          type: 'emphasis',
-          style: 'sesame',
-          children: [{ type: 'text', content: emphasisMatch[1] }],
-        });
+        pushEmphasis(nodes, emphasisMatch[1], 'sesame');
         remaining = remaining.slice(emphasisMatch[0].length);
         continue;
       }
       var circleEmphasisMatch = remaining.match(/^［＃「([^」]+)」に丸傍点］/);
       if (circleEmphasisMatch) {
-        nodes.push({
-          type: 'emphasis',
-          style: 'circle',
-          children: [{ type: 'text', content: circleEmphasisMatch[1] }],
-        });
+        pushEmphasis(nodes, circleEmphasisMatch[1], 'circle');
         remaining = remaining.slice(circleEmphasisMatch[0].length);
         continue;
       }
@@ -177,6 +178,22 @@
       }
     }
     return nodes;
+  }
+
+  // 傍点注記は青空文庫では後置記法 (対象テキストが本文に現れた「後」に注記が続く)。
+  // 例: `先生［＃「先生」に傍点］` の場合、parseInline はまず `先生` を text ノードに
+  // 積むため、注記処理時に直前 text ノード末尾から同じ文字列を剥がさないと二重表示になる。
+  function pushEmphasis(nodes, target, style) {
+    if (nodes.length > 0) {
+      var last = nodes[nodes.length - 1];
+      if (last && last.type === 'text' && last.content.length >= target.length &&
+          last.content.slice(last.content.length - target.length) === target) {
+        last.content = last.content.slice(0, last.content.length - target.length);
+        if (last.content === '') nodes.pop();
+      }
+    }
+    // emphasis の中身も parseInline に通し、内側の ruby / explicit-ruby / 未対応注記を解釈する
+    nodes.push({ type: 'emphasis', style: style, children: parseInline(target) });
   }
 
   function findNextSpecial(text) {
@@ -202,22 +219,27 @@
   function splitChapters(nodes) {
     var chapters = [];
     var currentTitle = '';
+    var currentTitleNodes = null;
     var currentNodes = [];
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i];
       if (node.type === 'heading') {
-        chapters.push({ title: currentTitle, nodes: currentNodes });
+        chapters.push({ title: currentTitle, titleNodes: currentTitleNodes, nodes: currentNodes });
         currentTitle = extractHeadingText(node.children);
+        // 見出し内 ruby / emphasis を保持したまま XHTML レンダリングするための元ノードを保存する
+        // (dc:title / TOC は plain text しか使えないため currentTitle も残す)
+        currentTitleNodes = node.children;
         currentNodes = [];
       } else if (node.type === 'pagebreak') {
-        chapters.push({ title: currentTitle, nodes: currentNodes });
+        chapters.push({ title: currentTitle, titleNodes: currentTitleNodes, nodes: currentNodes });
         currentTitle = '';
+        currentTitleNodes = null;
         currentNodes = [];
       } else {
         currentNodes.push(node);
       }
     }
-    chapters.push({ title: currentTitle, nodes: currentNodes });
+    chapters.push({ title: currentTitle, titleNodes: currentTitleNodes, nodes: currentNodes });
     return chapters.filter(function (ch) {
       if (ch.title !== '') return true;
       return hasMeaningfulContent(ch.nodes);
@@ -251,8 +273,14 @@
   // EPUB Builder
   // ============================================================
 
+  // XML 1.0 で許可されていない制御文字を除去する。許可されるのは U+0009 (Tab) /
+  // U+000A (LF) / U+000D (CR) と U+0020 以降のみ。破損 TXT や Shift_JIS の stray NUL 等が
+  // XHTML に混入すると epubcheck 等の厳格リーダーで書籍全体が読めなくなるため予防する。
+  var XML10_ILLEGAL = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g;
+
   function escapeXml(str) {
     return str
+      .replace(XML10_ILLEGAL, '')
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
@@ -294,10 +322,16 @@
     return result;
   }
 
-  function buildChapterXhtml(title, nodes) {
+  function buildChapterXhtml(title, nodes, titleNodes) {
     var body = nodesToXhtml(nodes);
     var titleEscaped = escapeXml(title);
-    var titleBlock = title ? '<p><b>' + titleEscaped + '</b></p>\n' : '';
+    // 章タイトルは titleNodes があれば ruby/emphasis を保持した XHTML でレンダリング
+    var titleBlock = '';
+    if (titleNodes && titleNodes.length > 0) {
+      titleBlock = '<p><b>' + nodesToXhtml(titleNodes) + '</b></p>\n';
+    } else if (title) {
+      titleBlock = '<p><b>' + titleEscaped + '</b></p>\n';
+    }
     return (
       '<?xml version="1.0" encoding="UTF-8"?>\n' +
       '<!DOCTYPE html>\n' +
@@ -452,7 +486,11 @@
     zip.file('OEBPS/style.css', buildStyleCss(), opts);
     for (var i = 0; i < chapters.length; i++) {
       var filename = 'chapter_' + pad3(i + 1) + '.xhtml';
-      zip.file('OEBPS/' + filename, buildChapterXhtml(chapters[i].title, chapters[i].nodes), opts);
+      zip.file(
+        'OEBPS/' + filename,
+        buildChapterXhtml(chapters[i].title, chapters[i].nodes, chapters[i].titleNodes),
+        opts
+      );
     }
     return await zip.generateAsync({
       type: 'blob',
@@ -485,9 +523,18 @@
   // UTF-8 で保存されたファイルも扱えるよう、UTF-8 (fatal) → Shift_JIS の順で試す。
   function decodeTxtAuto(buf) {
     var uint8 = new Uint8Array(buf);
-    // UTF-8 BOM: EF BB BF
+    // UTF-8 BOM: EF BB BF。BOM があっても fatal で厳密デコードする。BOM を貼り付けたまま
+    // Shift_JIS で再保存された事故ファイルは U+FFFD で silently 埋まる代わりにここで例外を投げ、
+    // Shift_JIS フォールバックへ流す。
     if (uint8.length >= 3 && uint8[0] === 0xef && uint8[1] === 0xbb && uint8[2] === 0xbf) {
-      return { text: new TextDecoder('utf-8').decode(buf), encoding: 'utf-8' };
+      try {
+        return {
+          text: new TextDecoder('utf-8', { fatal: true }).decode(buf),
+          encoding: 'utf-8-bom',
+        };
+      } catch (e) {
+        // Fall through to Shift_JIS
+      }
     }
     // UTF-8 として厳密デコード。日本語を含む Shift_JIS はほぼ確実にここで失敗する
     // (Shift_JIS 2バイト目 0x40-0xFC が UTF-8 continuation range 0x80-0xBF から外れるため)。

--- a/src/network/html/js/aozora-epub.js
+++ b/src/network/html/js/aozora-epub.js
@@ -481,17 +481,41 @@
     return { title: fallbackTitle, author: '不明' };
   }
 
+  // 青空文庫の配布 TXT は歴史的経緯から Shift_JIS が標準。BOM 付き UTF-8 や
+  // UTF-8 で保存されたファイルも扱えるよう、UTF-8 (fatal) → Shift_JIS の順で試す。
+  function decodeTxtAuto(buf) {
+    var uint8 = new Uint8Array(buf);
+    // UTF-8 BOM: EF BB BF
+    if (uint8.length >= 3 && uint8[0] === 0xef && uint8[1] === 0xbb && uint8[2] === 0xbf) {
+      return { text: new TextDecoder('utf-8').decode(buf), encoding: 'utf-8' };
+    }
+    // UTF-8 として厳密デコード。日本語を含む Shift_JIS はほぼ確実にここで失敗する
+    // (Shift_JIS 2バイト目 0x40-0xFC が UTF-8 continuation range 0x80-0xBF から外れるため)。
+    try {
+      return {
+        text: new TextDecoder('utf-8', { fatal: true }).decode(buf),
+        encoding: 'utf-8',
+      };
+    } catch (e) {
+      // Shift_JIS で再挑戦。ブラウザの 'shift_jis' ラベルは CP932 (Windows-31J) にマッピングされる。
+      try {
+        return {
+          text: new TextDecoder('shift_jis', { fatal: true }).decode(buf),
+          encoding: 'shift_jis',
+        };
+      } catch (e2) {
+        throw new Error('文字コードを判別できませんでした (UTF-8 / Shift_JIS どちらでも不正なバイトを検出)。');
+      }
+    }
+  }
+
   async function convertTxtToEpub(file, progressCallback) {
     var cb = typeof progressCallback === 'function' ? progressCallback : function () {};
 
     cb(0.05);
     var buf = await file.arrayBuffer();
-    var text;
-    try {
-      text = new TextDecoder('utf-8', { fatal: true }).decode(buf);
-    } catch (e) {
-      throw new Error('UTF-8デコードに失敗しました。Shift_JISファイルは非対応です。');
-    }
+    var decoded = decodeTxtAuto(buf);
+    var text = decoded.text;
 
     cb(0.15);
     var meta = extractTitleAuthor(text, file.name);
@@ -517,7 +541,7 @@
 
     cb(1.0);
     var epubName = file.name.replace(/\.txt$/i, '.epub');
-    return { blob: blob, name: epubName };
+    return { blob: blob, name: epubName, encoding: decoded.encoding };
   }
 
   window.AozoraEpub = {
@@ -526,5 +550,6 @@
     buildEpub: buildEpub,
     extractTitleAuthor: extractTitleAuthor,
     convertTxtToEpub: convertTxtToEpub,
+    decodeTxtAuto: decodeTxtAuto,
   };
 })();

--- a/src/network/html/js/aozora-epub.js
+++ b/src/network/html/js/aozora-epub.js
@@ -1,0 +1,530 @@
+// 青空文庫形式 TXT → EPUB3 変換モジュール
+// 参考実装: https://github.com/zrn-ns/aozora-epub-api (lib/aozora-parser.ts, chapter-splitter.ts, epub-builder.ts)
+// 依存: JSZip (js/jszip.min.js を先にロードすること)
+(function () {
+  'use strict';
+
+  // ============================================================
+  // Aozora Parser
+  // ============================================================
+
+  function parseAozoraText(text) {
+    var normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    var withoutHeader = removeSymbolBlock(normalized);
+    var withoutTitle = removeTitleBlock(withoutHeader);
+    return parseLines(withoutTitle);
+  }
+
+  // 「テキスト中に現れる記号について」を含む -------ブロックを除去する
+  function removeSymbolBlock(text) {
+    var lines = text.split('\n');
+    var result = [];
+    var inBlock = false;
+    var blockLines = [];
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (!inBlock && /^-{7,}/.test(line)) {
+        inBlock = true;
+        blockLines = [line];
+      } else if (inBlock) {
+        blockLines.push(line);
+        if (/^-{7,}/.test(line)) {
+          var blockContent = blockLines.join('\n');
+          if (blockContent.indexOf('【テキスト中に現れる記号について】') === -1) {
+            for (var j = 0; j < blockLines.length; j++) result.push(blockLines[j]);
+          }
+          inBlock = false;
+          blockLines = [];
+        }
+      } else {
+        result.push(line);
+      }
+    }
+    if (inBlock) {
+      for (var k = 0; k < blockLines.length; k++) result.push(blockLines[k]);
+    }
+    return result.join('\n');
+  }
+
+  // 最初の空行までのタイトル/著者ブロックを本文から取り除く
+  function removeTitleBlock(text) {
+    var lines = text.split('\n');
+    var firstBlankIndex = -1;
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].trim() === '') {
+        firstBlankIndex = i;
+        break;
+      }
+    }
+    if (firstBlankIndex === -1) return '';
+    return lines.slice(firstBlankIndex + 1).join('\n');
+  }
+
+  function parseLines(text) {
+    var lines = text.split('\n');
+    var nodes = [];
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (line.trim() === '') {
+        nodes.push({ type: 'newline' });
+        continue;
+      }
+      if (line.trim() === '［＃改ページ］') {
+        nodes.push({ type: 'pagebreak' });
+        continue;
+      }
+      var indentHeadingMatch = line.match(
+        /^［＃([0-9０-９]+)字下げ］(.+)［＃「(.+)」は(大|中|小)見出し］$/
+      );
+      if (indentHeadingMatch) {
+        nodes.push({
+          type: 'heading',
+          level: headingLevelFromSize(indentHeadingMatch[4]),
+          children: parseInline(indentHeadingMatch[3]),
+        });
+        continue;
+      }
+      var indentMatch = line.match(/^［＃([0-9０-９]+)字下げ］(.*)$/);
+      if (indentMatch) {
+        nodes.push({
+          type: 'indent',
+          chars: parseJapaneseNumber(indentMatch[1]),
+          children: parseInline(indentMatch[2]),
+        });
+        continue;
+      }
+      var headingMatch = line.match(/^(.*)［＃「(.+)」は(大|中|小)見出し］(.*)$/);
+      if (headingMatch) {
+        nodes.push({
+          type: 'heading',
+          level: headingLevelFromSize(headingMatch[3]),
+          children: parseInline(headingMatch[2]),
+        });
+        continue;
+      }
+      // 通常行: 1行 = 1段落（<br/>羅列を避けCJK縦書きでのメモリ圧を下げる）
+      nodes.push({ type: 'paragraph', children: parseInline(line) });
+    }
+    return nodes;
+  }
+
+  function parseJapaneseNumber(s) {
+    var normalized = s.replace(/[０-９]/g, function (c) {
+      return String.fromCharCode(c.charCodeAt(0) - 0xff10 + 0x30);
+    });
+    return parseInt(normalized, 10);
+  }
+
+  function headingLevelFromSize(size) {
+    if (size === '大') return 1;
+    if (size === '中') return 2;
+    if (size === '小') return 3;
+    return 1;
+  }
+
+  function parseInline(text) {
+    var nodes = [];
+    var remaining = text;
+    while (remaining.length > 0) {
+      var explicitRubyMatch = remaining.match(/^｜([^《]+)《([^》]+)》/);
+      if (explicitRubyMatch) {
+        nodes.push({ type: 'ruby', base: explicitRubyMatch[1], reading: explicitRubyMatch[2] });
+        remaining = remaining.slice(explicitRubyMatch[0].length);
+        continue;
+      }
+      var rubyMatch = remaining.match(/^([一-鿿㐀-䶿々〇ヶ]+)《([^》]+)》/);
+      if (rubyMatch) {
+        nodes.push({ type: 'ruby', base: rubyMatch[1], reading: rubyMatch[2] });
+        remaining = remaining.slice(rubyMatch[0].length);
+        continue;
+      }
+      var emphasisMatch = remaining.match(/^［＃「([^」]+)」に傍点］/);
+      if (emphasisMatch) {
+        nodes.push({
+          type: 'emphasis',
+          style: 'sesame',
+          children: [{ type: 'text', content: emphasisMatch[1] }],
+        });
+        remaining = remaining.slice(emphasisMatch[0].length);
+        continue;
+      }
+      var circleEmphasisMatch = remaining.match(/^［＃「([^」]+)」に丸傍点］/);
+      if (circleEmphasisMatch) {
+        nodes.push({
+          type: 'emphasis',
+          style: 'circle',
+          children: [{ type: 'text', content: circleEmphasisMatch[1] }],
+        });
+        remaining = remaining.slice(circleEmphasisMatch[0].length);
+        continue;
+      }
+      var aozoraAnnotationMatch = remaining.match(/^［＃[^］]*］/);
+      if (aozoraAnnotationMatch) {
+        remaining = remaining.slice(aozoraAnnotationMatch[0].length);
+        continue;
+      }
+      var nextSpecialIndex = findNextSpecial(remaining);
+      if (nextSpecialIndex > 0) {
+        nodes.push({ type: 'text', content: remaining.slice(0, nextSpecialIndex) });
+        remaining = remaining.slice(nextSpecialIndex);
+      } else if (nextSpecialIndex === 0) {
+        nodes.push({ type: 'text', content: remaining[0] });
+        remaining = remaining.slice(1);
+      } else {
+        nodes.push({ type: 'text', content: remaining });
+        remaining = '';
+      }
+    }
+    return nodes;
+  }
+
+  function findNextSpecial(text) {
+    var minIndex = -1;
+    var pipeIdx = text.indexOf('｜');
+    if (pipeIdx !== -1) minIndex = pipeIdx;
+    var rubyMatch = text.match(/[一-鿿㐀-䶿々〇ヶ]+《/);
+    if (rubyMatch && rubyMatch.index !== undefined) {
+      var idx = rubyMatch.index;
+      if (minIndex === -1 || idx < minIndex) minIndex = idx;
+    }
+    var annoIdx = text.indexOf('［＃');
+    if (annoIdx !== -1) {
+      if (minIndex === -1 || annoIdx < minIndex) minIndex = annoIdx;
+    }
+    return minIndex;
+  }
+
+  // ============================================================
+  // Chapter Splitter
+  // ============================================================
+
+  function splitChapters(nodes) {
+    var chapters = [];
+    var currentTitle = '';
+    var currentNodes = [];
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (node.type === 'heading') {
+        chapters.push({ title: currentTitle, nodes: currentNodes });
+        currentTitle = extractHeadingText(node.children);
+        currentNodes = [];
+      } else if (node.type === 'pagebreak') {
+        chapters.push({ title: currentTitle, nodes: currentNodes });
+        currentTitle = '';
+        currentNodes = [];
+      } else {
+        currentNodes.push(node);
+      }
+    }
+    chapters.push({ title: currentTitle, nodes: currentNodes });
+    return chapters.filter(function (ch) {
+      if (ch.title !== '') return true;
+      return hasMeaningfulContent(ch.nodes);
+    });
+  }
+
+  function extractHeadingText(children) {
+    var out = '';
+    for (var i = 0; i < children.length; i++) {
+      var node = children[i];
+      if (node.type === 'text') out += node.content;
+      else if (node.type === 'ruby') out += node.base;
+      else if (node.type === 'emphasis' || node.type === 'indent' || node.type === 'heading') {
+        out += extractHeadingText(node.children);
+      }
+    }
+    return out;
+  }
+
+  function hasMeaningfulContent(nodes) {
+    for (var i = 0; i < nodes.length; i++) {
+      var t = nodes[i].type;
+      if (t === 'text' || t === 'ruby' || t === 'emphasis' || t === 'indent' || t === 'paragraph' || t === 'pagebreak') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ============================================================
+  // EPUB Builder
+  // ============================================================
+
+  function escapeXml(str) {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  function nodesToXhtml(nodes) {
+    var result = '';
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      switch (node.type) {
+        case 'text':
+          result += escapeXml(node.content);
+          break;
+        case 'ruby':
+          result += '<ruby>' + escapeXml(node.base) + '<rt>' + escapeXml(node.reading) + '</rt></ruby>';
+          break;
+        case 'heading':
+          // <h> は EPUB リーダーのフォントサイズ設定を上書きするので使わない
+          result += '<p><b>' + nodesToXhtml(node.children) + '</b></p>';
+          break;
+        case 'indent':
+          result += '<p style="text-indent: ' + node.chars + 'em">' + nodesToXhtml(node.children) + '</p>';
+          break;
+        case 'paragraph':
+          result += '<p>' + nodesToXhtml(node.children) + '</p>';
+          break;
+        case 'emphasis':
+          result += '<em class="' + node.style + '">' + nodesToXhtml(node.children) + '</em>';
+          break;
+        case 'pagebreak':
+          break;
+        case 'newline':
+          result += '<br/>\n';
+          break;
+      }
+    }
+    return result;
+  }
+
+  function buildChapterXhtml(title, nodes) {
+    var body = nodesToXhtml(nodes);
+    var titleEscaped = escapeXml(title);
+    var titleBlock = title ? '<p><b>' + titleEscaped + '</b></p>\n' : '';
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<!DOCTYPE html>\n' +
+      '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja">\n' +
+      '<head>\n' +
+      '  <meta charset="UTF-8"/>\n' +
+      '  <title>' + titleEscaped + '</title>\n' +
+      '  <link rel="stylesheet" type="text/css" href="style.css"/>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      titleBlock +
+      body +
+      '\n</body>\n</html>'
+    );
+  }
+
+  function buildContainerXml() {
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n' +
+      '  <rootfiles>\n' +
+      '    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>\n' +
+      '  </rootfiles>\n' +
+      '</container>'
+    );
+  }
+
+  function pad3(n) {
+    var s = String(n);
+    while (s.length < 3) s = '0' + s;
+    return s;
+  }
+
+  function buildContentOpf(title, author, chapters, uid) {
+    var titleEscaped = escapeXml(title);
+    var authorEscaped = escapeXml(author);
+    var manifestItems = '';
+    var spineItems = '';
+    for (var i = 0; i < chapters.length; i++) {
+      var id = 'chapter_' + pad3(i + 1);
+      manifestItems +=
+        '    <item id="' + id + '" href="' + id + '.xhtml" media-type="application/xhtml+xml"/>\n';
+      spineItems += '    <itemref idref="' + id + '"/>\n';
+    }
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid" xml:lang="ja">\n' +
+      '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n' +
+      '    <dc:identifier id="uid">' + escapeXml(uid) + '</dc:identifier>\n' +
+      '    <dc:title>' + titleEscaped + '</dc:title>\n' +
+      '    <dc:creator>' + authorEscaped + '</dc:creator>\n' +
+      '    <dc:language>ja</dc:language>\n' +
+      '  </metadata>\n' +
+      '  <manifest>\n' +
+      '    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>\n' +
+      '    <item id="css" href="style.css" media-type="text/css"/>\n' +
+      manifestItems +
+      '  </manifest>\n' +
+      '  <spine page-progression-direction="rtl">\n' +
+      '    <itemref idref="nav" linear="no"/>\n' +
+      spineItems +
+      '  </spine>\n' +
+      '</package>'
+    );
+  }
+
+  function buildNavXhtml(title, chapters) {
+    var titleEscaped = escapeXml(title);
+    var tocItems = '';
+    for (var i = 0; i < chapters.length; i++) {
+      var id = 'chapter_' + pad3(i + 1);
+      var chapterTitle = chapters[i].title || (title + ' - ' + (i + 1));
+      tocItems +=
+        '      <li><a href="' + id + '.xhtml">' + escapeXml(chapterTitle) + '</a></li>\n';
+    }
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<!DOCTYPE html>\n' +
+      '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja">\n' +
+      '<head>\n' +
+      '  <meta charset="UTF-8"/>\n' +
+      '  <title>' + titleEscaped + '</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '  <nav epub:type="toc">\n' +
+      '    <h1>' + titleEscaped + '</h1>\n' +
+      '    <ol>\n' +
+      tocItems +
+      '    </ol>\n' +
+      '  </nav>\n' +
+      '</body>\n' +
+      '</html>'
+    );
+  }
+
+  function buildStyleCss() {
+    return (
+      '/* CrossPoint Aozora EPUB Style */\n' +
+      'html {\n' +
+      '  writing-mode: vertical-rl;\n' +
+      '  -epub-writing-mode: vertical-rl;\n' +
+      '  -webkit-writing-mode: vertical-rl;\n' +
+      '}\n' +
+      'ruby rt {\n' +
+      '  font-size: 0.5em;\n' +
+      '}\n' +
+      'em.sesame {\n' +
+      '  font-style: normal;\n' +
+      '  text-emphasis: sesame;\n' +
+      '  -webkit-text-emphasis: sesame;\n' +
+      '}\n' +
+      'em.circle {\n' +
+      '  font-style: normal;\n' +
+      '  text-emphasis: circle;\n' +
+      '  -webkit-text-emphasis: circle;\n' +
+      '}\n' +
+      'p[style*="text-indent"] {\n' +
+      '  margin: 0;\n' +
+      '  padding: 0;\n' +
+      '}\n'
+    );
+  }
+
+  // 疑似UUID (crypto.randomUUID があれば使う、なければ Math.random ベース)
+  function makeUid() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return 'urn:uuid:' + crypto.randomUUID();
+    }
+    var s = '';
+    for (var i = 0; i < 32; i++) {
+      s += Math.floor(Math.random() * 16).toString(16);
+    }
+    return 'urn:uuid:' + s.slice(0, 8) + '-' + s.slice(8, 12) + '-' + s.slice(12, 16) + '-' + s.slice(16, 20) + '-' + s.slice(20, 32);
+  }
+
+  async function buildEpub(options) {
+    if (typeof JSZip === 'undefined') {
+      throw new Error('JSZipが読み込まれていません。');
+    }
+    var title = options.title;
+    var author = options.author;
+    var chapters = options.chapters;
+    var uid = options.uid || makeUid();
+
+    var zip = new JSZip();
+    // mimetype は EPUB 仕様により最初のエントリ・非圧縮 (STORE) 必須
+    zip.file('mimetype', 'application/epub+zip', { compression: 'STORE' });
+    var opts = { compression: 'DEFLATE', compressionOptions: { level: 6 } };
+    zip.file('META-INF/container.xml', buildContainerXml(), opts);
+    zip.file('OEBPS/content.opf', buildContentOpf(title, author, chapters, uid), opts);
+    zip.file('OEBPS/nav.xhtml', buildNavXhtml(title, chapters), opts);
+    zip.file('OEBPS/style.css', buildStyleCss(), opts);
+    for (var i = 0; i < chapters.length; i++) {
+      var filename = 'chapter_' + pad3(i + 1) + '.xhtml';
+      zip.file('OEBPS/' + filename, buildChapterXhtml(chapters[i].title, chapters[i].nodes), opts);
+    }
+    return await zip.generateAsync({
+      type: 'blob',
+      mimeType: 'application/epub+zip',
+    });
+  }
+
+  // ============================================================
+  // Public helpers
+  // ============================================================
+
+  // 冒頭2行からタイトル/著者を抽出、失敗時はファイル名フォールバック
+  function extractTitleAuthor(text, filename) {
+    var normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    var lines = normalized.split('\n');
+    var line1 = (lines[0] || '').trim();
+    var line2 = (lines[1] || '').trim();
+    var line3 = (lines[2] || '').trim();
+    var fallbackTitle = filename.replace(/\.txt$/i, '');
+    if (line1 && line2 && line3 === '') {
+      return { title: line1, author: line2 };
+    }
+    if (line1 && line2 === '') {
+      return { title: line1, author: '不明' };
+    }
+    return { title: fallbackTitle, author: '不明' };
+  }
+
+  async function convertTxtToEpub(file, progressCallback) {
+    var cb = typeof progressCallback === 'function' ? progressCallback : function () {};
+
+    cb(0.05);
+    var buf = await file.arrayBuffer();
+    var text;
+    try {
+      text = new TextDecoder('utf-8', { fatal: true }).decode(buf);
+    } catch (e) {
+      throw new Error('UTF-8デコードに失敗しました。Shift_JISファイルは非対応です。');
+    }
+
+    cb(0.15);
+    var meta = extractTitleAuthor(text, file.name);
+
+    cb(0.30);
+    var nodes = parseAozoraText(text);
+    if (nodes.length === 0) {
+      throw new Error('本文が空です。');
+    }
+
+    cb(0.50);
+    var chapters = splitChapters(nodes);
+    if (chapters.length === 0) {
+      throw new Error('章分割の結果が空になりました。');
+    }
+
+    cb(0.70);
+    var blob = await buildEpub({
+      title: meta.title,
+      author: meta.author,
+      chapters: chapters,
+    });
+
+    cb(1.0);
+    var epubName = file.name.replace(/\.txt$/i, '.epub');
+    return { blob: blob, name: epubName };
+  }
+
+  window.AozoraEpub = {
+    parseAozoraText: parseAozoraText,
+    splitChapters: splitChapters,
+    buildEpub: buildEpub,
+    extractTitleAuthor: extractTitleAuthor,
+    convertTxtToEpub: convertTxtToEpub,
+  };
+})();


### PR DESCRIPTION
## 概要

ファイル転送機能で青空文庫形式の TXT をアップロードする際、ブラウザ側 (JavaScript) で EPUB3 に変換してから送信する機能を追加します。

## 動機

日本語 TXT をデバイスの `TxtReaderActivity` で開くと、CJK / UTF-8 マルチバイト処理で `std::string::substr()` や `getTextWidth()` を CJK 文字数ぶん呼び出す ([src/activities/reader/TxtReaderActivity.cpp:246-274](../blob/master/src/activities/reader/TxtReaderActivity.cpp#L246-L274))。ESP32-C3 の 380KB RAM 制約下でヒープが断片化し、日本語書籍の多くが実質開けない状態でした。

本改修ではブラウザ側で EPUB に変換してから送信することで、デバイス側は既存の高効率な EPUB 読み込みパスに乗り、ヒープ断片化を回避します。

## 変更内容

### 新規追加
- **`src/network/html/js/aozora-epub.js`** — 青空文庫 TXT → EPUB3 変換モジュール
  - `window.AozoraEpub.{parseAozoraText, splitChapters, buildEpub, extractTitleAuthor, convertTxtToEpub, decodeTxtAuto}`
  - 対応記法: ルビ、傍点、大中小見出し、字下げ、改ページ、段落
  - 文字コード: UTF-8 / UTF-8-BOM / Shift_JIS を自動判別
  - EPUB3: 章分割、`writing-mode: vertical-rl`、`page-progression-direction="rtl"`
  - 参考実装: [zrn-ns/aozora-epub-api](https://github.com/zrn-ns/aozora-epub-api)

### 統合
- **`src/network/CrossPointWebServer.{cpp,h}`** — `/js/aozora-epub.js` の gzip 配信ルート
- **`src/network/html/FilesPage.html`** — アップロードパイプラインに TXT→EPUB 変換分岐を追加
  - `.txt` 検出時に「青空文庫 TXT → EPUB に変換」チェックボックスを表示
  - **opt-in** (デフォルト OFF) — 既存の TXT アップロード挙動を保護
  - 変換成功: `.epub` 拡張子で送信 / 変換失敗: 元 TXT をフォールバックアップロード

### コードレビュー対応
xhigh レベルのコードレビューで発見された 15 件の findings のうち 12 件を修正しました。主な修正:
- 傍点注記の二重出力
- 見出し regex の可視テキスト保持 (章番号消失の修正)
- 章タイトルの ruby / emphasis 保持
- BOM 付きファイルの fatal デコード (silent U+FFFD 汚染回避)
- XML 1.0 違反の制御文字除去
- TXT 変換を opt-in 化 (既存挙動 regression 防止)
- 変換失敗時のフォールバック挙動を EPUB/XTC と統一

## Known Issue (follow-up 予定)
- `［＃ここから2字下げ］` などの未対応注記が silent drop される (対応記法の追加は範囲拡大のため別 PR)
- `extractTitleAuthor` が 2-3 行のプリアンブルにしか対応しない (副題や翻訳者行を持つファイルは追加対応必要)

## Test plan
- [x] 青空文庫サンプル (Shift_JIS / UTF-8 両方) を実機でアップロード → EPUB として保存
- [x] デバイスの EPUB リーダーで開ける (`TxtReaderActivity` に落ちない)
- [x] ルビ (`下人《げにん》`) が正しく表示される
- [x] `［＃改ページ］` で章が分かれる
- [x] 見出し (`［＃「第一章」は大見出し］`) が太字段落として表示される
- [x] 縦書き (`writing-mode: vertical-rl`) が効いている
- [x] 傍点付きの本文が二重表示にならない
- [x] 変換 OFF 時は既存挙動 (.txt が直接アップロード) を維持
- [x] .epub / .zip / 通常ファイルのアップロードが既存通り動作する
- [x] `pio run -e default` がエラー・警告 0 で成功
- [x] Node.js 単体テストで parser/decoder の主要ケースを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)