### PR TITLE
chore: v0.1.11

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 0.1.10
+version = 0.1.11
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
## Summary

v0.1.10 → v0.1.11 のパッチリリース。

## 主な変更（v0.1.10 以降の master 上のマージ）

- **fix**: OTA アップデート確認が失敗する不具合を修正 ([#76](https://github.com/zrn-ns/crosspoint-jp/pull/76))
- **feat**: 本家 crosspoint-reader のディスプレイ表示最適化を取り込み ([#77](https://github.com/zrn-ns/crosspoint-jp/pull/77))
- **fix**: 青空文庫ダウンロード履歴の断片化クラッシュを解消 ([#78](https://github.com/zrn-ns/crosspoint-jp/pull/78))
- **feat**: 青空文庫TXTをブラウザ側でEPUBに変換してからアップロードする機能を追加 ([#79](https://github.com/zrn-ns/crosspoint-jp/pull/79)) — **本PRのマージ前に #79 を先にマージすること**

## マージ順序

このリリースPRは #79 のマージ後にリベース/マージしてください。#79 が未マージのままこのPRをマージすると、リリースタグに #79 の内容が含まれなくなります。

## リリース後の作業

- master マージ後、tag v0.1.11 を打つ・GitHub Release を作成する（既存フロー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)