### PR TITLE
fix: OTAアップデートが常に検証失敗する問題を修正 (v0.1.12)

### DIFF
--- a/lib/Memory/Memory.h
+++ b/lib/Memory/Memory.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+// Nothrow versions of std::make_unique. Return nullptr on allocation failure
+// instead of calling abort() (the default when exceptions are disabled on ESP32).
+//
+// Single object:
+//   auto obj = makeUniqueNoThrow<PNG>();
+//   if (!obj) { LOG_ERR("TAG", "OOM"); return false; }
+//
+// Array:
+//   auto buf = makeUniqueNoThrow<uint8_t[]>(size);
+//   if (!buf) { LOG_ERR("TAG", "OOM"); return false; }
+//   buf[0] = 0xFF;
+//   someApi(buf.get(), size);
+//
+
+template <typename T, typename... Args>
+  requires(!std::is_array_v<T>)
+std::unique_ptr<T> makeUniqueNoThrow(Args&&... args) {
+  return std::unique_ptr<T>(new (std::nothrow) T(std::forward<Args>(args)...));
+}
+
+template <typename T>
+  requires std::is_unbounded_array_v<T>
+std::unique_ptr<T> makeUniqueNoThrow(size_t count) {
+  using Elem = std::remove_extent_t<T>;
+  return std::unique_ptr<T>(new (std::nothrow) Elem[count]());
+}
+
+// Helper struct to call a cleanup function on exit from any scope.
+// Use with a lambda to avoid unnecessary allocations from std::function/std::bind:
+// Example:
+//   auto jpeg = makeUniqueNoThrow<JPEGDEC>();
+//   ScopedCleanup cleanup{[&jpeg]{ jpeg->close(); }};
+//
+template <typename F>
+struct [[nodiscard]] ScopedCleanup final {
+  const F fn;
+  explicit ScopedCleanup(F f) : fn{std::move(f)} {}
+  ScopedCleanup(const ScopedCleanup&) = delete;
+  ScopedCleanup& operator=(const ScopedCleanup&) = delete;
+  ScopedCleanup(ScopedCleanup&&) = delete;
+  ScopedCleanup& operator=(ScopedCleanup&&) = delete;
+  ~ScopedCleanup() { fn(); }
+};
+
+template <typename F>
+ScopedCleanup(F) -> ScopedCleanup<F>;

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 0.1.11
+version = 0.1.12
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ build_flags =
 # Default is (320*4+1)*2=2562, we need more for larger images
   -DPNG_MAX_BUFFERED_PIXELS=16416
   -Wno-bidi-chars
-  -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort
+  -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort,--wrap=bootloader_common_check_efuse_blk_validity
   -fno-exceptions
 # Size optimization flags (CJK: needed to prevent boot loop with large CJK fonts)
   -Os

--- a/scripts/git_branch.py
+++ b/scripts/git_branch.py
@@ -79,6 +79,11 @@ def get_version_from_git_tag(project_dir):
 
 
 def get_base_version(project_dir):
+    # Env var override (OTA test / debug): highest priority
+    override = os.environ.get('OTA_TEST_VERSION')
+    if override:
+        return override
+
     # Prefer version from latest git tag (single source of truth)
     git_version = get_version_from_git_tag(project_dir)
     if git_version:

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -159,7 +159,9 @@ static bool fetchApiJson(const char* url, JsonDocument& doc) {
       LOG_DBG("AOZORA", "Retry %d/%d", attempt + 1, API_MAX_RETRIES);
       delay(1000);
     }
-    result = HttpDownloader::downloadToFile(url, API_TMP_FILE, nullptr, 30000);
+    // HttpDownloader は esp_http_client の HTTP_TIMEOUT_MS=60000 を使うため、
+    // 従来 fork にあった 30000 ms タイムアウト引数は不要 (本家 API に合わせて除去)。
+    result = HttpDownloader::downloadToFile(url, API_TMP_FILE);
     if (result == HttpDownloader::OK) break;
     LOG_ERR("AOZORA", "API fetch attempt %d failed: err=%d http=%d", attempt + 1, result, HttpDownloader::lastHttpCode);
     Storage.remove(API_TMP_FILE);
@@ -315,14 +317,12 @@ bool AozoraActivity::downloadBook() {
     return false;
   }
 
-  auto result = HttpDownloader::downloadToFile(
-      std::string(url), std::string(destPath),
-      [this](size_t downloaded, size_t total) {
-        downloadProgress_ = downloaded;
-        downloadTotal_ = total;
-        requestUpdate(true);
-      },
-      30000);
+  auto result = HttpDownloader::downloadToFile(std::string(url), std::string(destPath),
+                                               [this](size_t downloaded, size_t total) {
+                                                 downloadProgress_ = downloaded;
+                                                 downloadTotal_ = total;
+                                                 requestUpdate(true);
+                                               });
 
   if (result != HttpDownloader::OK) {
     LOG_ERR("AOZORA", "Download failed: err=%d http=%d", static_cast<int>(result), HttpDownloader::lastHttpCode);
@@ -372,14 +372,12 @@ bool AozoraActivity::updateBook() {
   Storage.remove(tmpPath);
 
   // 一時ファイルにダウンロード（既存ファイルはこの時点では無傷）
-  auto result = HttpDownloader::downloadToFile(
-      std::string(url), std::string(tmpPath),
-      [this](size_t downloaded, size_t total) {
-        downloadProgress_ = downloaded;
-        downloadTotal_ = total;
-        requestUpdate(true);
-      },
-      30000);
+  auto result = HttpDownloader::downloadToFile(std::string(url), std::string(tmpPath),
+                                               [this](size_t downloaded, size_t total) {
+                                                 downloadProgress_ = downloaded;
+                                                 downloadTotal_ = total;
+                                                 requestUpdate(true);
+                                               });
 
   if (result != HttpDownloader::OK) {
     LOG_ERR("AOZORA", "Update download failed: err=%d http=%d", static_cast<int>(result), HttpDownloader::lastHttpCode);

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -317,12 +317,12 @@ bool AozoraActivity::downloadBook() {
     return false;
   }
 
-  auto result = HttpDownloader::downloadToFile(std::string(url), std::string(destPath),
-                                               [this](size_t downloaded, size_t total) {
-                                                 downloadProgress_ = downloaded;
-                                                 downloadTotal_ = total;
-                                                 requestUpdate(true);
-                                               });
+  auto result =
+      HttpDownloader::downloadToFile(std::string(url), std::string(destPath), [this](size_t downloaded, size_t total) {
+        downloadProgress_ = downloaded;
+        downloadTotal_ = total;
+        requestUpdate(true);
+      });
 
   if (result != HttpDownloader::OK) {
     LOG_ERR("AOZORA", "Download failed: err=%d http=%d", static_cast<int>(result), HttpDownloader::lastHttpCode);
@@ -372,12 +372,12 @@ bool AozoraActivity::updateBook() {
   Storage.remove(tmpPath);
 
   // 一時ファイルにダウンロード（既存ファイルはこの時点では無傷）
-  auto result = HttpDownloader::downloadToFile(std::string(url), std::string(tmpPath),
-                                               [this](size_t downloaded, size_t total) {
-                                                 downloadProgress_ = downloaded;
-                                                 downloadTotal_ = total;
-                                                 requestUpdate(true);
-                                               });
+  auto result =
+      HttpDownloader::downloadToFile(std::string(url), std::string(tmpPath), [this](size_t downloaded, size_t total) {
+        downloadProgress_ = downloaded;
+        downloadTotal_ = total;
+        requestUpdate(true);
+      });
 
   if (result != HttpDownloader::OK) {
     LOG_ERR("AOZORA", "Update download failed: err=%d http=%d", static_cast<int>(result), HttpDownloader::lastHttpCode);

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -19,7 +19,13 @@ class FontDownloadActivity : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool preventAutoSleep() override { return state_ == LOADING_MANIFEST || state_ == DOWNLOADING; }
+  bool preventAutoSleep() override {
+    return state_ == LOADING_MANIFEST || state_ == DOWNLOADING ||
+           // The download is synchronous and blocks the main loop until it
+           // completes, so activityManager.preventAutoSleep() is never polled
+           // during downloading.
+           state_ == COMPLETE || state_ == ERROR;
+  }
   bool skipLoopDelay() override { return true; }
 
  private:

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -139,11 +139,6 @@ void OtaUpdateActivity::render(RenderLock&&) {
 }
 
 void OtaUpdateActivity::loop() {
-  // TODO @ngxson : refactor this logic later
-  if (updater.getRender()) {
-    requestUpdate();
-  }
-
   if (state == WAITING_CONFIRMATION) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
       LOG_DBG("OTA", "New update available, starting download...");
@@ -152,7 +147,14 @@ void OtaUpdateActivity::loop() {
         state = UPDATE_IN_PROGRESS;
       }
       requestUpdateAndWait();
-      const auto res = updater.installUpdate();
+      const auto res = updater.installUpdate(
+          [](void* ctx) {
+            // immediate=true notifies the render task directly. The default deferred path only
+            // sets a flag consumed at the end of ActivityManager::loop(), which never runs while
+            // installUpdate() blocks this task.
+            static_cast<OtaUpdateActivity*>(ctx)->requestUpdate(true);
+          },
+          this);
 
       if (res != OtaUpdater::OK) {
         LOG_DBG("OTA", "Update failed: %d", res);

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -128,6 +128,19 @@ void OtaUpdateActivity::render(RenderLock&&) {
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   } else if (state == FAILED) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_UPDATE_FAILED), true, EpdFontFamily::BOLD);
+    // シリアルが取れない環境向け診断: '|' 区切りで2行に分割して描画 (画面幅に収まるよう)
+    const auto& detail = updater.getLastErrorDetail();
+    if (!detail.empty()) {
+      const auto pipe = detail.find('|');
+      const int row1 = top + height + metrics.verticalSpacing;
+      if (pipe == std::string::npos) {
+        renderer.drawCenteredText(UI_10_FONT_ID, row1, detail.c_str());
+      } else {
+        renderer.drawCenteredText(UI_10_FONT_ID, row1, detail.substr(0, pipe).c_str());
+        renderer.drawCenteredText(UI_10_FONT_ID, row1 + height + metrics.verticalSpacing,
+                                  detail.substr(pipe + 1).c_str());
+      }
+    }
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   } else if (state == FINISHED) {

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -1,347 +1,214 @@
 #include "HttpDownloader.h"
 
-#include <HTTPClient.h>
+#include <Arduino.h>
 #include <Logging.h>
-#include <NetworkClient.h>
-#include <NetworkClientSecure.h>
-#include <StreamString.h>
+#include <Memory.h>
 #include <base64.h>
+#include <esp_crt_bundle.h>
+#include <esp_http_client.h>
 
 #include <cstring>
-#include <memory>
-#include <utility>
+#include <functional>
+#include <string>
 
-#include "CrossPointSettings.h"
-#include "util/UrlUtils.h"
-
+// fork-only: activities show this in error messages for diagnostics
 int HttpDownloader::lastHttpCode = 0;
 
 namespace {
-class FileWriteStream final : public Stream {
- public:
-  FileWriteStream(FsFile& file, size_t total, HttpDownloader::ProgressCallback progress)
-      : file_(file), total_(total), progress_(std::move(progress)) {}
+// RX holds the response headers. 4096 fits real OPDS servers; GitHub's release
+// CDN sends more and logs HTTP_HEADER "Buffer length is small", but that's
+// non-fatal: the headers we read (Location, Content-Length) come first and
+// survive. Smaller keeps contiguous heap free while WiFi and TLS are up. TX
+// only carries our GET; the body streams in READ_CHUNK pieces.
+constexpr int HTTP_RX_BUF = 4096;
+constexpr int HTTP_TX_BUF = 1024;
+// Per-socket-op timeout. Some OPDS download endpoints are slow to send headers
+// (>15s) and chunked catalogs stall mid-body, so 15s killed them. 60s gives
+// slow servers room. esp_http_client's timeout_ms is uint32, so unlike Arduino
+// HTTPClient's uint16 setTimeout it doesn't silently truncate.
+constexpr int HTTP_TIMEOUT_MS = 60000;
+constexpr size_t READ_CHUNK = 2048;
 
-  size_t write(uint8_t byte) override { return write(&byte, 1); }
-
-  size_t write(const uint8_t* buffer, size_t size) override {
-    // Write-through stream for HTTPClient::writeToStream with progress tracking.
-    const size_t written = file_.write(buffer, size);
-    if (written != size) {
-      writeOk_ = false;
-    }
-    downloaded_ += written;
-    if (progress_ && total_ > 0) {
-      progress_(downloaded_, total_);
-    }
-    return written;
-  }
-
-  int available() override { return 0; }
-  int read() override { return -1; }
-  int peek() override { return -1; }
-  void flush() override { file_.flush(); }
-
-  size_t downloaded() const { return downloaded_; }
-  bool ok() const { return writeOk_; }
-
- private:
-  FsFile& file_;
-  size_t total_;
-  size_t downloaded_ = 0;
-  bool writeOk_ = true;
-  HttpDownloader::ProgressCallback progress_;
-};
-}  // namespace
-
-bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username,
-                              const std::string& password) {
-  // Streaming variant: identical connection setup to the std::string overload,
-  // but pushes body chunks into onData instead of buffering them. Used by the
-  // OTA release-check path where TLS session heap + full-body buffer would OOM.
-  std::unique_ptr<NetworkClient> client;
-  if (UrlUtils::isHttpsUrl(url)) {
-    auto* secureClient = new NetworkClientSecure();
-    secureClient->setInsecure();
-    secureClient->setHandshakeTimeout(20);
-    client.reset(secureClient);
-  } else {
-    client.reset(new NetworkClient());
-  }
-  HTTPClient http;
-
-  http.begin(*client, url.c_str());
-  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-
-  if (!username.empty() && !password.empty()) {
-    std::string credentials = username + ":" + password;
-    String encoded = base64::encode(credentials.c_str());
-    http.addHeader("Authorization", "Basic " + encoded);
-  }
-
-  LOG_DBG("HTTP", "FetchStream: %s (heap=%d)", url.c_str(), ESP.getFreeHeap());
-  const int httpCode = http.GET();
-  lastHttpCode = httpCode;
-
-  if (httpCode != HTTP_CODE_OK) {
-    LOG_ERR("HTTP", "FetchStream failed: %d", httpCode);
-    http.end();
-    return false;
-  }
-
-  NetworkClient* stream = http.getStreamPtr();
-  uint8_t buf[512];
+struct Sink {
+  std::function<bool(const uint8_t*, size_t)> write;  // returns false to abort the transfer
+  HttpDownloader::ProgressCallback progress;
+  bool* cancelFlag = nullptr;
   size_t total = 0;
-  bool aborted = false;
-  while (stream->available() || stream->connected()) {
-    int avail = stream->available();
-    if (avail <= 0) {
-      delay(1);
-      continue;
-    }
-    int toRead = (avail < static_cast<int>(sizeof(buf))) ? avail : static_cast<int>(sizeof(buf));
-    int bytesRead = stream->readBytes(buf, toRead);
-    if (bytesRead <= 0) break;
-    if (onData && !onData(buf, static_cast<size_t>(bytesRead))) {
-      aborted = true;
-      break;
-    }
-    total += bytesRead;
-  }
-  http.end();
+  size_t downloaded = 0;
+};
 
-  if (aborted) {
-    LOG_DBG("HTTP", "FetchStream aborted by callback after %zu bytes", total);
-    return false;
-  }
-  if (total == 0) {
-    LOG_ERR("HTTP", "FetchStream: empty body");
-    lastHttpCode = -901;
-    return false;
-  }
-
-  LOG_DBG("HTTP", "FetchStream success: %zu bytes", total);
-  return true;
+bool isRedirect(int status) {
+  return status == 301 || status == 302 || status == 303 || status == 307 || status == 308;
 }
+
+// Streams a GET body through sink.write in READ_CHUNK pieces. Uses the manual
+// open/fetch_headers/read path rather than esp_http_client_perform(): perform()
+// pushes the whole body through an event callback and reports a chunked body
+// that ends early as ESP_ERR_HTTP_INCOMPLETE_DATA, whereas the read loop streams
+// large/slow files and surfaces a short read directly.
+HttpDownloader::DownloadError runGet(const std::string& url, const std::string& username, const std::string& password,
+                                     Sink& sink) {
+  HttpDownloader::lastHttpCode = 0;  // reset before each attempt so activities' diagnostics reflect this call only
+  esp_http_client_config_t config = {};
+  config.url = url.c_str();
+  config.buffer_size = HTTP_RX_BUF;
+  config.buffer_size_tx = HTTP_TX_BUF;
+  config.timeout_ms = HTTP_TIMEOUT_MS;
+  // Verify HTTPS against the bundled CA roots. This build has esp-tls
+  // CONFIG_ESP_TLS_INSECURE off, so an unverified TLS handshake can't be set
+  // up at all; the model is public servers over verified https and local
+  // servers over plain http (esp_http_client picks the transport from the URL
+  // scheme, so http:// needs no cert config). The prior setInsecure() worked
+  // only because Arduino's ssl_client drives mbedtls directly.
+  config.crt_bundle_attach = esp_crt_bundle_attach;
+  config.keep_alive_enable = true;
+
+  esp_http_client_handle_t client = esp_http_client_init(&config);
+  if (!client) {
+    LOG_ERR("HTTP", "client init failed");
+    return HttpDownloader::HTTP_ERROR;
+  }
+
+  esp_http_client_set_header(client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  if (!username.empty() && !password.empty()) {
+    // Preemptive Basic auth, like the prior addHeader; don't wait for a 401.
+    const std::string credentials = username + ":" + password;
+    const String header = "Basic " + base64::encode(credentials.c_str());
+    esp_http_client_set_header(client, "Authorization", header.c_str());
+  }
+
+  // open()/read() does not auto-follow redirects (only perform() does), so step
+  // 30x responses manually. OPDS download endpoints and the GitHub release CDN
+  // both redirect.
+  esp_err_t err = esp_http_client_open(client, 0);
+  if (err != ESP_OK) {
+    LOG_ERR("HTTP", "open failed: %s", esp_err_to_name(err));
+    esp_http_client_cleanup(client);
+    return HttpDownloader::HTTP_ERROR;
+  }
+  int64_t contentLength = esp_http_client_fetch_headers(client);
+  int status = esp_http_client_get_status_code(client);
+  for (int hop = 0; isRedirect(status) && hop < 5; ++hop) {
+    if (esp_http_client_set_redirection(client) != ESP_OK) break;
+    err = esp_http_client_open(client, 0);
+    if (err != ESP_OK) {
+      LOG_ERR("HTTP", "redirect open failed: %s", esp_err_to_name(err));
+      esp_http_client_cleanup(client);
+      return HttpDownloader::HTTP_ERROR;
+    }
+    contentLength = esp_http_client_fetch_headers(client);
+    status = esp_http_client_get_status_code(client);
+  }
+  HttpDownloader::lastHttpCode = status;
+
+  if (status != 200) {
+    LOG_ERR("HTTP", "unexpected status: %d", status);
+    esp_http_client_cleanup(client);
+    return HttpDownloader::HTTP_ERROR;
+  }
+
+  // fetch_headers returns 0 for a chunked response (no Content-Length); leave
+  // total at 0 so progress stays silent and the size check is skipped.
+  sink.total = contentLength > 0 ? static_cast<size_t>(contentLength) : 0;
+
+  auto buf = makeUniqueNoThrow<char[]>(READ_CHUNK);
+  if (!buf) {
+    LOG_ERR("HTTP", "OOM: %u byte read buffer", (unsigned)READ_CHUNK);
+    esp_http_client_cleanup(client);
+    return HttpDownloader::HTTP_ERROR;
+  }
+
+  while (true) {
+    if (sink.cancelFlag && *sink.cancelFlag) {
+      esp_http_client_cleanup(client);
+      return HttpDownloader::ABORTED;
+    }
+    const int read = esp_http_client_read(client, buf.get(), READ_CHUNK);
+    if (read < 0) {
+      LOG_ERR("HTTP", "read error after %zu bytes", sink.downloaded);
+      esp_http_client_cleanup(client);
+      return HttpDownloader::HTTP_ERROR;
+    }
+    if (read == 0) break;  // all data received
+    if (!sink.write(reinterpret_cast<const uint8_t*>(buf.get()), read)) {
+      esp_http_client_cleanup(client);
+      return HttpDownloader::FILE_ERROR;
+    }
+    sink.downloaded += read;
+    if (sink.progress && sink.total > 0) sink.progress(sink.downloaded, sink.total);
+  }
+
+  const bool complete = esp_http_client_is_complete_data_received(client);
+  esp_http_client_cleanup(client);
+  if (!complete) {
+    LOG_ERR("HTTP", "incomplete: got %zu of %zu bytes", sink.downloaded, sink.total);
+    return HttpDownloader::HTTP_ERROR;
+  }
+  return HttpDownloader::OK;
+}
+}  // namespace
 
 bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const std::string& username,
                               const std::string& password) {
-  // Use NetworkClientSecure for HTTPS, regular NetworkClient for HTTP
-  std::unique_ptr<NetworkClient> client;
-  if (UrlUtils::isHttpsUrl(url)) {
-    auto* secureClient = new NetworkClientSecure();
-    secureClient->setInsecure();
-    secureClient->setHandshakeTimeout(20);
-    client.reset(secureClient);
-  } else {
-    client.reset(new NetworkClient());
-  }
-  HTTPClient http;
-
   LOG_DBG("HTTP", "Fetching: %s", url.c_str());
-
-  http.begin(*client, url.c_str());
-  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-
-  if (!username.empty() && !password.empty()) {
-    std::string credentials = username + ":" + password;
-    String encoded = base64::encode(credentials.c_str());
-    http.addHeader("Authorization", "Basic " + encoded);
-  }
-
-  LOG_DBG("HTTP", "Free heap before GET: %d", ESP.getFreeHeap());
-  const int httpCode = http.GET();
-  lastHttpCode = httpCode;
-  LOG_DBG("HTTP", "GET result: %d, free heap: %d", httpCode, ESP.getFreeHeap());
-  if (httpCode != HTTP_CODE_OK) {
-    LOG_ERR("HTTP", "Fetch failed: %d", httpCode);
-    http.end();
-    return false;
-  }
-
-  const int writeResult = http.writeToStream(&outContent);
-  http.end();
-
-  if (writeResult < 0) {
-    LOG_ERR("HTTP", "writeToStream failed: %d", writeResult);
-    lastHttpCode = writeResult;
-    return false;
-  }
-
-  LOG_DBG("HTTP", "Fetch success: %d bytes", writeResult);
-  return true;
+  Sink sink;
+  sink.write = [&outContent](const uint8_t* data, size_t len) { return outContent.write(data, len) == len; };
+  return runGet(url, username, password, sink) == OK;
 }
 
 bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent, const std::string& username,
                               const std::string& password) {
-  // Direct string fetch: avoids StreamString and writeToStream issues.
-  std::unique_ptr<NetworkClient> client;
-  if (UrlUtils::isHttpsUrl(url)) {
-    auto* secureClient = new NetworkClientSecure();
-    secureClient->setInsecure();
-    secureClient->setHandshakeTimeout(20);
-    client.reset(secureClient);
-  } else {
-    client.reset(new NetworkClient());
-  }
-  HTTPClient http;
+  LOG_DBG("HTTP", "Fetching: %s", url.c_str());
+  outContent.clear();  // start clean; the sink appends, so don't carry prior content
+  Sink sink;
+  sink.write = [&outContent](const uint8_t* data, size_t len) {
+    outContent.append(reinterpret_cast<const char*>(data), len);
+    return true;
+  };
+  return runGet(url, username, password, sink) == OK;
+}
 
-  http.begin(*client, url.c_str());
-  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-
-  if (!username.empty() && !password.empty()) {
-    std::string credentials = username + ":" + password;
-    String encoded = base64::encode(credentials.c_str());
-    http.addHeader("Authorization", "Basic " + encoded);
-  }
-
-  LOG_DBG("HTTP", "FetchStr: %s (heap=%d)", url.c_str(), ESP.getFreeHeap());
-  const int httpCode = http.GET();
-  lastHttpCode = httpCode;
-
-  if (httpCode != HTTP_CODE_OK) {
-    LOG_ERR("HTTP", "FetchStr failed: %d", httpCode);
-    http.end();
-    return false;
-  }
-
-  // Read body in small chunks to avoid large single allocation.
-  // TLS buffers (~40KB) are held during the connection, leaving limited heap.
-  NetworkClient* stream = http.getStreamPtr();
-  const int contentLen = http.getSize();
-  outContent.clear();
-  if (contentLen > 0) {
-    outContent.reserve(contentLen);
-  }
-
-  char buf[512];
-  while (stream->available() || stream->connected()) {
-    int avail = stream->available();
-    if (avail <= 0) {
-      delay(1);
-      continue;
-    }
-    int toRead = (avail < static_cast<int>(sizeof(buf))) ? avail : static_cast<int>(sizeof(buf));
-    int bytesRead = stream->readBytes(buf, toRead);
-    if (bytesRead > 0) {
-      outContent.append(buf, bytesRead);
-    } else {
-      break;
-    }
-  }
-  http.end();
-
-  if (outContent.empty()) {
-    LOG_ERR("HTTP", "FetchStr: empty body (contentLen=%d)", contentLen);
-    lastHttpCode = -901;
-    return false;
-  }
-
-  LOG_DBG("HTTP", "FetchStr success: %zu bytes", outContent.size());
-  return true;
+bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username,
+                              const std::string& password) {
+  LOG_DBG("HTTP", "Fetching: %s", url.c_str());
+  Sink sink;
+  sink.write = onData;
+  return runGet(url, username, password, sink) == OK;
 }
 
 HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url, const std::string& destPath,
-                                                             ProgressCallback progress, int timeoutMs,
+                                                             ProgressCallback progress, bool* cancelFlag,
                                                              const std::string& username, const std::string& password) {
-  // Use NetworkClientSecure for HTTPS, regular NetworkClient for HTTP
-  std::unique_ptr<NetworkClient> client;
-  if (UrlUtils::isHttpsUrl(url)) {
-    auto* secureClient = new NetworkClientSecure();
-    secureClient->setInsecure();
-    secureClient->setHandshakeTimeout(20);
-    client.reset(secureClient);
-  } else {
-    client.reset(new NetworkClient());
-  }
-  HTTPClient http;
+  LOG_DBG("HTTP", "Downloading: %s -> %s", url.c_str(), destPath.c_str());
 
-  LOG_DBG("HTTP", "Downloading: %s", url.c_str());
-  LOG_DBG("HTTP", "Destination: %s", destPath.c_str());
-
-  http.begin(*client, url.c_str());
-  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  if (timeoutMs > 0) {
-    http.setTimeout(timeoutMs);
-  }
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-
-  if (!username.empty() && !password.empty()) {
-    std::string credentials = username + ":" + password;
-    String encoded = base64::encode(credentials.c_str());
-    http.addHeader("Authorization", "Basic " + encoded);
-  }
-
-  const int httpCode = http.GET();
-  lastHttpCode = httpCode;
-  if (httpCode != HTTP_CODE_OK) {
-    LOG_ERR("HTTP", "Download failed: %d", httpCode);
-    http.end();
-    return HTTP_ERROR;
-  }
-
-  const int64_t reportedLength = http.getSize();
-  const size_t contentLength = reportedLength > 0 ? static_cast<size_t>(reportedLength) : 0;
-  if (contentLength > 0) {
-    LOG_DBG("HTTP", "Content-Length: %zu", contentLength);
-  } else {
-    LOG_DBG("HTTP", "Content-Length: unknown");
-  }
-
-  // Remove existing file if present
   if (Storage.exists(destPath.c_str())) {
     Storage.remove(destPath.c_str());
   }
-
-  // Open file for writing
-  FsFile file;
+  HalFile file;
   if (!Storage.openFileForWrite("HTTP", destPath.c_str(), file)) {
     LOG_ERR("HTTP", "Failed to open file for writing");
-    http.end();
     return FILE_ERROR;
   }
 
-  // Let HTTPClient handle chunked decoding and stream body bytes into the file.
-  FileWriteStream fileStream(file, contentLength, progress);
-  const int writeResult = http.writeToStream(&fileStream);
+  Sink sink;
+  sink.progress = std::move(progress);
+  sink.cancelFlag = cancelFlag;
+  sink.write = [&file](const uint8_t* data, size_t len) { return file.write(data, len) == len; };
 
+  const DownloadError result = runGet(url, username, password, sink);
+  // Close before any remove() on the same path; DESTRUCTOR_CLOSES_FILE would
+  // otherwise close only after the remove.
   file.close();
-  http.end();
 
-  if (writeResult < 0) {
-    LOG_ERR("HTTP", "writeToStream error: %d (len=%zu)", writeResult, contentLength);
-    lastHttpCode = writeResult;  // Store writeToStream error code for diagnostics
+  if (result != OK) {
+    Storage.remove(destPath.c_str());
+    return result;
+  }
+  if (sink.downloaded == 0) {
+    LOG_ERR("HTTP", "no data received");
     Storage.remove(destPath.c_str());
     return HTTP_ERROR;
   }
-
-  const size_t downloaded = fileStream.downloaded();
-  LOG_DBG("HTTP", "Downloaded %zu bytes", downloaded);
-
-  // Guard against partial writes even if HTTPClient completes.
-  if (!fileStream.ok()) {
-    LOG_ERR("HTTP", "Write failed during download");
-    lastHttpCode = -900;  // Custom code: SD write failure
-    Storage.remove(destPath.c_str());
-    return FILE_ERROR;
-  }
-
-  if (contentLength == 0 && downloaded == 0) {
-    LOG_ERR("HTTP", "Download failed: no data received");
-    lastHttpCode = -901;  // Custom code: no data
-    Storage.remove(destPath.c_str());
-    return HTTP_ERROR;
-  }
-
-  // Verify download size if known
-  if (contentLength > 0 && downloaded != contentLength) {
-    LOG_ERR("HTTP", "Size mismatch: got %zu, expected %zu", downloaded, contentLength);
-    Storage.remove(destPath.c_str());
-    return HTTP_ERROR;
-  }
-
+  LOG_DBG("HTTP", "Downloaded %zu bytes", sink.downloaded);
   return OK;
 }

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -31,11 +31,16 @@ int HttpDownloader::lastHttpCode = 0;
 
 namespace {
 #if !defined(FREEINK_NET_WOLFSSL)
-// RX holds the response headers. Smaller buffers leave enough contiguous heap
-// for mbedTLS on redirect-heavy OPDS feeds while still preserving the headers
-// we read directly (Location, Content-Length).
-constexpr int HTTP_RX_BUF = 2048;
-constexpr int HTTP_TX_BUF = 512;
+// RX holds the response headers; TX must fit the whole request line.
+// fork: upstream shrank these to 2048/512, but upstream routes OTA/large
+// downloads through wolfSSL (runGetWolf) — here runGet carries them too.
+// GitHub's release CDN redirect target (objects.githubusercontent.com) is a
+// signed URL whose path+query runs 700-900 bytes, so the redirected GET's
+// request line overflows a 512-byte TX buffer and the reopen fails before any
+// byte arrives. 4096/1024 is the configuration that fully downloaded the 6MB
+// image on this device (see #2074 cherry-pick 0d40ec1a).
+constexpr int HTTP_RX_BUF = 4096;
+constexpr int HTTP_TX_BUF = 1024;
 #endif
 // Per-socket-op timeout. Some OPDS download endpoints are slow to send headers
 // (>15s) and chunked catalogs stall mid-body, so 15s killed them. 60s gives
@@ -164,17 +169,20 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   esp_err_t err = esp_http_client_open(client, 0);
   if (err != ESP_OK) {
     LOG_ERR("HTTP", "open failed: %s", esp_err_to_name(err));
+    HttpDownloader::lastHttpCode = -static_cast<int>(err);  // fork: 負値=esp_err で診断表示
     esp_http_client_cleanup(client);
     return HttpDownloader::HTTP_ERROR;
   }
   int64_t contentLength = esp_http_client_fetch_headers(client);
   int status = esp_http_client_get_status_code(client);
   for (int hop = 0; isRedirect(status) && hop < MAX_REDIRECTS; ++hop) {
+    HttpDownloader::lastHttpCode = status;  // fork: redirect 中の失敗でも直前の status を残す
     if (esp_http_client_set_redirection(client) != ESP_OK) break;
     esp_http_client_close(client);
     err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
       LOG_ERR("HTTP", "redirect open failed: %s", esp_err_to_name(err));
+      HttpDownloader::lastHttpCode = -static_cast<int>(err);  // fork: 負値=esp_err で診断表示
       esp_http_client_cleanup(client);
       return HttpDownloader::HTTP_ERROR;
     }

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -4,30 +4,37 @@
 #include <Logging.h>
 #include <Memory.h>
 #include <base64.h>
-#include <esp_crt_bundle.h>
-#include <esp_http_client.h>
 
-#include <cstring>
 #include <functional>
 #include <string>
+
+#if defined(FREEINK_NET_WOLFSSL)
+#include <SecureHttpClient.h>
+
+extern "C" void wolfSSL_Arduino_Serial_Print(const char* const msg) { LOG_DBG("WOLFSSL", "%s", msg); }
+#else
+#include <esp_crt_bundle.h>
+#include <esp_http_client.h>
+#endif
 
 // fork-only: activities show this in error messages for diagnostics
 int HttpDownloader::lastHttpCode = 0;
 
 namespace {
-// RX holds the response headers. 4096 fits real OPDS servers; GitHub's release
-// CDN sends more and logs HTTP_HEADER "Buffer length is small", but that's
-// non-fatal: the headers we read (Location, Content-Length) come first and
-// survive. Smaller keeps contiguous heap free while WiFi and TLS are up. TX
-// only carries our GET; the body streams in READ_CHUNK pieces.
-constexpr int HTTP_RX_BUF = 4096;
-constexpr int HTTP_TX_BUF = 1024;
+#if !defined(FREEINK_NET_WOLFSSL)
+// RX holds the response headers. Smaller buffers leave enough contiguous heap
+// for mbedTLS on redirect-heavy OPDS feeds while still preserving the headers
+// we read directly (Location, Content-Length).
+constexpr int HTTP_RX_BUF = 2048;
+constexpr int HTTP_TX_BUF = 512;
+#endif
 // Per-socket-op timeout. Some OPDS download endpoints are slow to send headers
 // (>15s) and chunked catalogs stall mid-body, so 15s killed them. 60s gives
 // slow servers room. esp_http_client's timeout_ms is uint32, so unlike Arduino
 // HTTPClient's uint16 setTimeout it doesn't silently truncate.
 constexpr int HTTP_TIMEOUT_MS = 60000;
-constexpr size_t READ_CHUNK = 2048;
+constexpr size_t READ_CHUNK = 1024;
+constexpr int MAX_REDIRECTS = 5;
 
 struct Sink {
   std::function<bool(const uint8_t*, size_t)> write;  // returns false to abort the transfer
@@ -41,6 +48,71 @@ bool isRedirect(int status) {
   return status == 301 || status == 302 || status == 303 || status == 307 || status == 308;
 }
 
+#if defined(FREEINK_NET_WOLFSSL)
+HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std::string& username,
+                                         const std::string& password, Sink& sink) {
+  std::string url = startUrl;
+
+  for (int hop = 0; hop <= MAX_REDIRECTS; ++hop) {
+    freeink::SecureHttpClient http;
+    http.setTimeout(HTTP_TIMEOUT_MS);
+    http.setInsecure();
+    if (!http.begin(url)) {
+      LOG_ERR("HTTP", "wolfSSL bad URL: %s", url.c_str());
+      return HttpDownloader::HTTP_ERROR;
+    }
+    // setUserAgent replaces SecureHttpClient's built-in UA; addHeader would
+    // append a second User-Agent header, which strict servers reject (aiohttp
+    // answers 400 "Duplicate 'User-Agent' header found").
+    http.setUserAgent("CrossPoint-ESP32-" CROSSPOINT_VERSION);
+    if (!username.empty() && !password.empty()) {
+      const std::string credentials = username + ":" + password;
+      const String encoded = base64::encode(credentials.c_str());
+      http.addHeader("Authorization", std::string("Basic ") + encoded.c_str());
+    }
+
+    LOG_DBG("HTTP", "wolfSSL GET: %s", url.c_str());
+    const int status = http.GET(
+        [&http, &sink](const uint8_t* data, size_t len) {
+          if (http.getStatus() != 200) return true;
+          if (sink.total == 0 && http.hasContentLength()) sink.total = http.getContentLength();
+          if (!sink.write(data, len)) return false;
+          sink.downloaded += len;
+          if (sink.progress && sink.total > 0) sink.progress(sink.downloaded, sink.total);
+          return true;
+        },
+        [&sink]() { return sink.cancelFlag && *sink.cancelFlag; });
+
+    if (http.aborted()) return HttpDownloader::ABORTED;
+    if (status < 0) {
+      LOG_ERR("HTTP", "wolfSSL request failed: %s", url.c_str());
+      return HttpDownloader::HTTP_ERROR;
+    }
+    if (isRedirect(status)) {
+      const std::string location = http.getHeader("location");
+      if (location.empty() || !freeink::SecureHttpClient::resolveUrl(url, location, url)) {
+        LOG_ERR("HTTP", "wolfSSL bad redirect: %d", status);
+        return HttpDownloader::HTTP_ERROR;
+      }
+      continue;
+    }
+    if (status != 200) {
+      LOG_ERR("HTTP", "wolfSSL unexpected status: %d", status);
+      return HttpDownloader::HTTP_ERROR;
+    }
+    if (http.callbackAborted()) return HttpDownloader::FILE_ERROR;
+    if (!http.responseComplete()) {
+      LOG_ERR("HTTP", "wolfSSL incomplete: got %zu of %zu bytes", sink.downloaded, sink.total);
+      return HttpDownloader::HTTP_ERROR;
+    }
+    return HttpDownloader::OK;
+  }
+  LOG_ERR("HTTP", "too many redirects");
+  return HttpDownloader::HTTP_ERROR;
+}
+#endif
+
+#if !defined(FREEINK_NET_WOLFSSL)
 // Streams a GET body through sink.write in READ_CHUNK pieces. Uses the manual
 // open/fetch_headers/read path rather than esp_http_client_perform(): perform()
 // pushes the whole body through an event callback and reports a chunked body
@@ -88,8 +160,9 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   }
   int64_t contentLength = esp_http_client_fetch_headers(client);
   int status = esp_http_client_get_status_code(client);
-  for (int hop = 0; isRedirect(status) && hop < 5; ++hop) {
+  for (int hop = 0; isRedirect(status) && hop < MAX_REDIRECTS; ++hop) {
     if (esp_http_client_set_redirection(client) != ESP_OK) break;
+    esp_http_client_close(client);
     err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
       LOG_ERR("HTTP", "redirect open failed: %s", esp_err_to_name(err));
@@ -146,6 +219,20 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   }
   return HttpDownloader::OK;
 }
+#endif  // !FREEINK_NET_WOLFSSL
+
+// All HTTP(S) fetches go through wolfSSL when it is the active TLS stack: it
+// speaks TLS 1.3 and reads large bodies from servers where the esp_http_client/
+// mbedTLS path fails to connect or stalls mid-stream. Plain-http URLs still use a
+// WiFiClient inside runGetWolf, so this is safe for non-TLS targets too.
+HttpDownloader::DownloadError runGetSecure(const std::string& url, const std::string& username,
+                                           const std::string& password, Sink& sink) {
+#if defined(FREEINK_NET_WOLFSSL)
+  return runGetWolf(url, username, password, sink);
+#else
+  return runGet(url, username, password, sink);
+#endif
+}
 }  // namespace
 
 bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const std::string& username,
@@ -153,7 +240,7 @@ bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const 
   LOG_DBG("HTTP", "Fetching: %s", url.c_str());
   Sink sink;
   sink.write = [&outContent](const uint8_t* data, size_t len) { return outContent.write(data, len) == len; };
-  return runGet(url, username, password, sink) == OK;
+  return runGetSecure(url, username, password, sink) == OK;
 }
 
 bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent, const std::string& username,
@@ -165,7 +252,7 @@ bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent, c
     outContent.append(reinterpret_cast<const char*>(data), len);
     return true;
   };
-  return runGet(url, username, password, sink) == OK;
+  return runGetSecure(url, username, password, sink) == OK;
 }
 
 bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username,
@@ -173,7 +260,7 @@ bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData
   LOG_DBG("HTTP", "Fetching: %s", url.c_str());
   Sink sink;
   sink.write = onData;
-  return runGet(url, username, password, sink) == OK;
+  return runGetSecure(url, username, password, sink) == OK;
 }
 
 HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url, const std::string& destPath,
@@ -195,7 +282,7 @@ HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& 
   sink.cancelFlag = cancelFlag;
   sink.write = [&file](const uint8_t* data, size_t len) { return file.write(data, len) == len; };
 
-  const DownloadError result = runGet(url, username, password, sink);
+  const DownloadError result = runGetSecure(url, username, password, sink);
   // Close before any remove() on the same path; DESTRUCTOR_CLOSES_FILE would
   // otherwise close only after the remove.
   file.close();

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -13,8 +13,17 @@
 
 extern "C" void wolfSSL_Arduino_Serial_Print(const char* const msg) { LOG_DBG("WOLFSSL", "%s", msg); }
 #else
-#include <esp_crt_bundle.h>
 #include <esp_http_client.h>
+
+/*
+ * When esp_crt_bundle.h is included, it points to the wrong header file
+ * (something under WiFiClientSecure) because our framework is based on the
+ * Arduino platform. To manage this obstacle, don't include anything, just
+ * extern and it will point to the correct one.
+ */
+extern "C" {
+extern esp_err_t esp_crt_bundle_attach(void* conf);
+}
 #endif
 
 // fork-only: activities show this in error messages for diagnostics

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -5,16 +5,15 @@
 #include <string>
 
 /**
- * HTTP client utility for fetching content and downloading files.
- * Wraps NetworkClientSecure and HTTPClient for HTTPS requests.
+ * HTTP client utility for fetching content and downloading files. Built on
+ * esp_http_client: https is verified against the CA bundle, plain http is
+ * used for local servers (transport is chosen from the URL scheme).
  */
 class HttpDownloader {
  public:
   using ProgressCallback = std::function<void(size_t downloaded, size_t total)>;
-  /// Streaming body callback: called with each response chunk as it arrives.
-  /// Return false to abort. Lets a streaming parser consume the response
-  /// without buffering the whole body (TLS session + full-body buffer would
-  /// otherwise contend for the same tight heap arena and OOM on ESP32-C3).
+  // Called with each body chunk as it arrives; return false to abort. Lets a
+  // streaming parser consume the response without buffering the whole body.
   using DataCallback = std::function<bool(const uint8_t* data, size_t len)>;
 
   enum DownloadError {
@@ -24,16 +23,14 @@ class HttpDownloader {
     ABORTED,
   };
 
-  /// Last HTTP status code from downloadToFile (-1 = connection failed, -11 = timeout, etc.)
+  // Last HTTP status code observed by runGet(). Fork-only: activities
+  // (Aozora / FontDownload) surface this in their error messages for
+  // diagnostics. Positive value = HTTP response code, 0 = never set / no
+  // response received. Not thread-safe (single-threaded HTTP path).
   static int lastHttpCode;
 
   /**
-   * Fetch text content from a URL with optional Basic auth credentials.
-   * @param url The URL to fetch
-   * @param outContent The fetched content (output)
-   * @param username Optional username for Basic auth
-   * @param password Optional password for Basic auth
-   * @return true if fetch succeeded, false on error
+   * Fetch text content from a URL with optional credentials.
    */
   static bool fetchUrl(const std::string& url, std::string& outContent, const std::string& username = "",
                        const std::string& password = "");
@@ -43,16 +40,14 @@ class HttpDownloader {
 
   /**
    * Stream the response body to onData as it arrives, without buffering it.
-   * Use when the response is large (>10KB) or when heap is tight during TLS
-   * (OTA release JSON check, streaming JSON parse, etc.).
    */
   static bool fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username = "",
                        const std::string& password = "");
 
   /**
-   * Download a file to the SD card with optional Basic auth credentials.
+   * Download a file to the SD card with optional credentials.
    */
   static DownloadError downloadToFile(const std::string& url, const std::string& destPath,
-                                      ProgressCallback progress = nullptr, int timeoutMs = 0,
+                                      ProgressCallback progress = nullptr, bool* cancelFlag = nullptr,
                                       const std::string& username = "", const std::string& password = "");
 };

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -154,12 +154,11 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate() {
   esp_http_client_config_t client_config = {
       .url = otaUrl.c_str(),
       .timeout_ms = 15000,
-      /* Default HTTP client buffer size 512 byte only
-       * not sufficient to handle URL redirection cases or
-       * parsing of large HTTP headers.
-       */
-      .buffer_size = 8192,
-      .buffer_size_tx = 8192,
+      // 4096 holds the github->CDN redirect headers (the 512 default truncates
+      // them); TX only carries our GET. Both are contiguous blocks contending
+      // with the TLS handshake on a tight internal arena, so keep them minimal.
+      .buffer_size = 4096,
+      .buffer_size_tx = 1024,
       .skip_cert_common_name_check = true,
       .crt_bundle_attach = esp_crt_bundle_attach,
       .keep_alive_enable = true,
@@ -179,11 +178,21 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate() {
     return INTERNAL_UPDATE_ERROR;
   }
 
+  int lastReportedPct = -1;
   do {
     esp_err = esp_https_ota_perform(ota_handle);
     processedSize = esp_https_ota_get_image_len_read(ota_handle);
-    /* Sent signal to  OtaUpdateActivity */
-    render = true;
+    // OtaUpdateActivity への render 要求を 1% 変化時のみに throttle する。
+    // 従来は毎 ~100ms perform iteration 毎に render を立てていて、render task の
+    // framebuffer 描画が TLS session と同じ内部 arena を奪い合い OOM を助長していた。
+    // E-ink は 1% tick より速く再描画できないのでこれで十分。
+    if (totalSize > 0) {
+      const int pct = static_cast<int>(static_cast<uint64_t>(processedSize) * 100 / totalSize);
+      if (pct != lastReportedPct) {
+        lastReportedPct = pct;
+        render = true;
+      }
+    }
     delay(100);  // TODO: should we replace this with something better?
   } while (esp_err == ESP_ERR_HTTPS_OTA_IN_PROGRESS);
 

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -11,14 +11,33 @@
 #include <esp_wifi.h>
 // clang-format on
 
+#include <cstring>
 #include <string>
 
 namespace {
-constexpr char latestReleaseUrl[] = "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/latest";
+constexpr char latestReleaseUrl[] = "https://api.github.com/repos/zrn-ns/crosspoint-jp/releases/latest";
+
+bool parseSemver3(const char* version, int* major, int* minor, int* patch) {
+  if (!version || !major || !minor || !patch) {
+    return false;
+  }
+  const char* p = version;
+  if (*p == 'v' || *p == 'V') {
+    p++;
+  }
+  return sscanf(p, "%d.%d.%d", major, minor, patch) == 3;
+}
 }  // namespace
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   LOG_DBG("OTA", "Checking for update (current: %s)", CROSSPOINT_VERSION);
+
+  updateAvailable = false;
+  latestVersion.clear();
+  otaUrl.clear();
+  otaSize = 0;
+  processedSize = 0;
+  totalSize = 0;
 
   // Stream the ~32KB release JSON straight into the parser as it arrives.
   // Buffering the whole body in a std::string would add a growing allocation
@@ -70,8 +89,11 @@ bool OtaUpdater::isUpdateNewer() const {
   const auto currentVersion = CROSSPOINT_VERSION;
 
   // semantic version check (only match on 3 segments)
-  sscanf(latestVersion.c_str(), "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch);
-  sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch);
+  if (!parseSemver3(latestVersion.c_str(), &latestMajor, &latestMinor, &latestPatch) ||
+      !parseSemver3(currentVersion, &currentMajor, &currentMinor, &currentPatch)) {
+    LOG_ERR("OTA", "Version parse failed: current=%s, latest=%s", currentVersion, latestVersion.c_str());
+    return false;
+  }
 
   /*
    * Compare major versions.

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -17,6 +17,13 @@
 namespace {
 constexpr char latestReleaseUrl[] = "https://api.github.com/repos/zrn-ns/crosspoint-jp/releases/latest";
 
+// esp_err_to_name の "ESP_ERR_" prefix を削って画面幅に収まる短い名前にする。
+const char* shortErrName(const char* name) {
+  if (!name) return "?";
+  if (strncmp(name, "ESP_ERR_", 8) == 0) return name + 8;
+  return name;
+}
+
 bool parseSemver3(const char* version, int* major, int* minor, int* patch) {
   if (!version || !major || !minor || !patch) {
     return false;
@@ -38,6 +45,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   otaSize = 0;
   processedSize = 0;
   totalSize = 0;
+  lastErrorDetail.clear();
 
   // Stream the ~32KB release JSON straight into the parser as it arrives.
   // Buffering the whole body in a std::string would add a growing allocation
@@ -51,6 +59,10 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   });
   if (!ok) {
     LOG_ERR("OTA", "Release check fetch failed");
+    char buf[64];
+    snprintf(buf, sizeof(buf), "fetch fail http=%d heap=%dKB", HttpDownloader::lastHttpCode,
+             static_cast<int>(ESP.getFreeHeap() / 1024));
+    lastErrorDetail = buf;
     return HTTP_ERROR;
   }
 
@@ -130,6 +142,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   if (!isUpdateNewer()) {
     return UPDATE_OLDER_ERROR;
   }
+  lastErrorDetail.clear();
 
   // esp_https_ota is hardwired to esp-tls/mbedTLS, whose precompiled build on this
   // package can't negotiate TLS 1.3 (see SecureClient.h). Drive the OTA partition
@@ -139,6 +152,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   const esp_partition_t* updatePartition = esp_ota_get_next_update_partition(nullptr);
   if (!updatePartition) {
     LOG_ERR("OTA", "No OTA partition available");
+    lastErrorDetail = "no ota partition";
     return INTERNAL_UPDATE_ERROR;
   }
 
@@ -146,6 +160,10 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   esp_err_t esp_err = esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle);
   if (esp_err != ESP_OK) {
     LOG_ERR("OTA", "esp_ota_begin failed: %s", esp_err_to_name(esp_err));
+    char buf[96];
+    snprintf(buf, sizeof(buf), "begin:%s heap=%dKB", shortErrName(esp_err_to_name(esp_err)),
+             static_cast<int>(ESP.getFreeHeap() / 1024));
+    lastErrorDetail = buf;
     return INTERNAL_UPDATE_ERROR;
   }
 
@@ -155,8 +173,10 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   processedSize = 0;
   int lastReportedPct = -1;
   bool flashOk = true;
+  esp_err_t writeErr = ESP_OK;
   const bool fetchOk = HttpDownloader::fetchUrl(otaUrl, [&](const uint8_t* data, size_t len) {
-    if (esp_ota_write(otaHandle, data, len) != ESP_OK) {
+    writeErr = esp_ota_write(otaHandle, data, len);
+    if (writeErr != ESP_OK) {
       flashOk = false;
       return false;  // abort the transfer
     }
@@ -179,6 +199,17 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
 
   if (!fetchOk || !flashOk) {
     LOG_ERR("OTA", "Firmware install failed (%s)", flashOk ? "download" : "flash write");
+    char buf[128];
+    if (!flashOk) {
+      snprintf(buf, sizeof(buf), "write:%s r=%d/%d|heap=%dKB blk=%dKB", shortErrName(esp_err_to_name(writeErr)),
+               static_cast<int>(processedSize), static_cast<int>(totalSize), static_cast<int>(ESP.getFreeHeap() / 1024),
+               static_cast<int>(ESP.getMaxAllocHeap() / 1024));
+    } else {
+      snprintf(buf, sizeof(buf), "fetch http=%d r=%d/%d|heap=%dKB blk=%dKB", HttpDownloader::lastHttpCode,
+               static_cast<int>(processedSize), static_cast<int>(totalSize), static_cast<int>(ESP.getFreeHeap() / 1024),
+               static_cast<int>(ESP.getMaxAllocHeap() / 1024));
+    }
+    lastErrorDetail = buf;
     esp_ota_abort(otaHandle);
     return flashOk ? HTTP_ERROR : INTERNAL_UPDATE_ERROR;
   }
@@ -186,12 +217,20 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   esp_err = esp_ota_end(otaHandle);  // verifies the written image
   if (esp_err != ESP_OK) {
     LOG_ERR("OTA", "esp_ota_end failed: %s", esp_err_to_name(esp_err));
+    char buf[128];
+    snprintf(buf, sizeof(buf), "end:%s r=%d/%d|heap=%dKB blk=%dKB", shortErrName(esp_err_to_name(esp_err)),
+             static_cast<int>(processedSize), static_cast<int>(totalSize), static_cast<int>(ESP.getFreeHeap() / 1024),
+             static_cast<int>(ESP.getMaxAllocHeap() / 1024));
+    lastErrorDetail = buf;
     return INTERNAL_UPDATE_ERROR;
   }
 
   esp_err = esp_ota_set_boot_partition(updatePartition);
   if (esp_err != ESP_OK) {
     LOG_ERR("OTA", "esp_ota_set_boot_partition failed: %s", esp_err_to_name(esp_err));
+    char buf[96];
+    snprintf(buf, sizeof(buf), "setboot:%s", shortErrName(esp_err_to_name(esp_err)));
+    lastErrorDetail = buf;
     return INTERNAL_UPDATE_ERROR;
   }
 

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -2,64 +2,29 @@
 
 // clang-format off
 // HttpDownloader.h pulls Arduino/SdFat, whose macros collide with lwip's
-// ip4_addr.h unless seen before esp_http_client (which includes lwip). Pin this
-// order; clang-format would otherwise sort the local header last and break the
-// build.
+// ip4_addr.h unless seen first. Pin this order; clang-format would otherwise sort
+// the local header last and break the build.
 #include "HttpDownloader.h"
 #include <Logging.h>
 #include <ReleaseJsonParser.h>
-#include <esp_http_client.h>
-#include <esp_https_ota.h>
+#include <esp_ota_ops.h>
 #include <esp_wifi.h>
 // clang-format on
 
-#include <cstring>
 #include <string>
 
 namespace {
-constexpr char latestReleaseUrl[] = "https://api.github.com/repos/zrn-ns/crosspoint-jp/releases/latest";
-
-/*
- * When esp_crt_bundle.h included, it is pointing wrong header file
- * which is something under WifiClientSecure because of our framework based on arduno platform.
- * To manage this obstacle, don't include anything, just extern and it will point correct one.
- */
-extern "C" {
-extern esp_err_t esp_crt_bundle_attach(void* conf);
-}
-
-bool parseSemver3(const char* version, int* major, int* minor, int* patch) {
-  if (!version || !major || !minor || !patch) {
-    return false;
-  }
-  const char* p = version;
-  if (*p == 'v' || *p == 'V') {
-    p++;
-  }
-  return sscanf(p, "%d.%d.%d", major, minor, patch) == 3;
-}
-
-esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
-  return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-}
-} /* namespace */
+constexpr char latestReleaseUrl[] = "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/latest";
+}  // namespace
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   LOG_DBG("OTA", "Checking for update (current: %s)", CROSSPOINT_VERSION);
 
-  updateAvailable = false;
-  latestVersion.clear();
-  otaUrl.clear();
-  otaSize = 0;
-  processedSize = 0;
-  totalSize = 0;
-
-  // Stream the release JSON straight into the parser as it arrives.
+  // Stream the ~32KB release JSON straight into the parser as it arrives.
   // Buffering the whole body in a std::string would add a growing allocation
   // on top of the TLS session's heap during the fetch; with -fno-exceptions an
-  // OOM there aborts. The old ArduinoJson + esp_http_client event_handler path
-  // also silently dropped chunked-transfer responses. HttpDownloader::fetchUrl
-  // handles verified-https GET, redirects, and User-Agent for us.
+  // OOM there aborts. fetchUrl handles the verified-https GET, redirects, and
+  // User-Agent (see HttpDownloader).
   ReleaseJsonParser releaseParser;
   const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&releaseParser](const uint8_t* data, size_t len) {
     releaseParser.feed(reinterpret_cast<const char*>(data), len);
@@ -89,7 +54,8 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   totalSize = otaSize;
   updateAvailable = true;
 
-  LOG_DBG("OTA", "Found update: %s, asset size=%u", latestVersion.c_str(), static_cast<unsigned int>(otaSize));
+  LOG_DBG("OTA", "Found update: tag=%s size=%zu", latestVersion.c_str(), otaSize);
+  LOG_DBG("OTA", "Firmware URL: %s", otaUrl.c_str());
   return OK;
 }
 
@@ -104,11 +70,8 @@ bool OtaUpdater::isUpdateNewer() const {
   const auto currentVersion = CROSSPOINT_VERSION;
 
   // semantic version check (only match on 3 segments)
-  if (!parseSemver3(latestVersion.c_str(), &latestMajor, &latestMinor, &latestPatch) ||
-      !parseSemver3(currentVersion, &currentMajor, &currentMinor, &currentPatch)) {
-    LOG_ERR("OTA", "Version parse failed: current=%s, latest=%s", currentVersion, latestVersion.c_str());
-    return false;
-  }
+  sscanf(latestVersion.c_str(), "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch);
+  sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch);
 
   /*
    * Compare major versions.
@@ -141,79 +104,72 @@ bool OtaUpdater::isUpdateNewer() const {
 
 const std::string& OtaUpdater::getLatestVersion() const { return latestVersion; }
 
-OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate() {
+OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgress, void* ctx) {
   if (!isUpdateNewer()) {
     return UPDATE_OLDER_ERROR;
   }
 
-  esp_https_ota_handle_t ota_handle = NULL;
-  esp_err_t esp_err;
-  /* Signal for OtaUpdateActivity */
-  render = false;
+  // esp_https_ota is hardwired to esp-tls/mbedTLS, whose precompiled build on this
+  // package can't negotiate TLS 1.3 (see SecureClient.h). Drive the OTA partition
+  // ourselves and stream the firmware through HttpDownloader, which runs over
+  // wolfSSL when FREEINK_NET_WOLFSSL is set, reusing its redirect handling for the
+  // GitHub -> CDN hop.
+  const esp_partition_t* updatePartition = esp_ota_get_next_update_partition(nullptr);
+  if (!updatePartition) {
+    LOG_ERR("OTA", "No OTA partition available");
+    return INTERNAL_UPDATE_ERROR;
+  }
 
-  esp_http_client_config_t client_config = {
-      .url = otaUrl.c_str(),
-      .timeout_ms = 15000,
-      // 4096 holds the github->CDN redirect headers (the 512 default truncates
-      // them); TX only carries our GET. Both are contiguous blocks contending
-      // with the TLS handshake on a tight internal arena, so keep them minimal.
-      .buffer_size = 4096,
-      .buffer_size_tx = 1024,
-      .skip_cert_common_name_check = true,
-      .crt_bundle_attach = esp_crt_bundle_attach,
-      .keep_alive_enable = true,
-  };
-
-  esp_https_ota_config_t ota_config = {
-      .http_config = &client_config,
-      .http_client_init_cb = http_client_set_header_cb,
-  };
+  esp_ota_handle_t otaHandle = 0;
+  esp_err_t esp_err = esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle);
+  if (esp_err != ESP_OK) {
+    LOG_ERR("OTA", "esp_ota_begin failed: %s", esp_err_to_name(esp_err));
+    return INTERNAL_UPDATE_ERROR;
+  }
 
   /* For better timing and connectivity, we disable power saving for WiFi */
   esp_wifi_set_ps(WIFI_PS_NONE);
 
-  esp_err = esp_https_ota_begin(&ota_config, &ota_handle);
-  if (esp_err != ESP_OK) {
-    LOG_DBG("OTA", "HTTP OTA Begin Failed: %s", esp_err_to_name(esp_err));
-    return INTERNAL_UPDATE_ERROR;
-  }
-
+  processedSize = 0;
   int lastReportedPct = -1;
-  do {
-    esp_err = esp_https_ota_perform(ota_handle);
-    processedSize = esp_https_ota_get_image_len_read(ota_handle);
-    // OtaUpdateActivity への render 要求を 1% 変化時のみに throttle する。
-    // 従来は毎 ~100ms perform iteration 毎に render を立てていて、render task の
-    // framebuffer 描画が TLS session と同じ内部 arena を奪い合い OOM を助長していた。
-    // E-ink は 1% tick より速く再描画できないのでこれで十分。
-    if (totalSize > 0) {
+  bool flashOk = true;
+  const bool fetchOk = HttpDownloader::fetchUrl(otaUrl, [&](const uint8_t* data, size_t len) {
+    if (esp_ota_write(otaHandle, data, len) != ESP_OK) {
+      flashOk = false;
+      return false;  // abort the transfer
+    }
+    processedSize += len;
+    // Fire the callback only on whole-percent change. Per-chunk updates wake the
+    // render task, whose framebuffer work contends with TLS on the internal arena,
+    // and e-ink can't repaint faster than a percent tick anyway.
+    if (onProgress && totalSize > 0) {
       const int pct = static_cast<int>(static_cast<uint64_t>(processedSize) * 100 / totalSize);
       if (pct != lastReportedPct) {
         lastReportedPct = pct;
-        render = true;
+        onProgress(ctx);
       }
     }
-    delay(100);  // TODO: should we replace this with something better?
-  } while (esp_err == ESP_ERR_HTTPS_OTA_IN_PROGRESS);
+    return true;
+  });
 
   /* Return back to default power saving for WiFi in case of failing */
   esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
 
-  if (esp_err != ESP_OK) {
-    LOG_ERR("OTA", "esp_https_ota_perform Failed: %s", esp_err_to_name(esp_err));
-    esp_https_ota_finish(ota_handle);
-    return HTTP_ERROR;
+  if (!fetchOk || !flashOk) {
+    LOG_ERR("OTA", "Firmware install failed (%s)", flashOk ? "download" : "flash write");
+    esp_ota_abort(otaHandle);
+    return flashOk ? HTTP_ERROR : INTERNAL_UPDATE_ERROR;
   }
 
-  if (!esp_https_ota_is_complete_data_received(ota_handle)) {
-    LOG_ERR("OTA", "esp_https_ota_is_complete_data_received Failed: %s", esp_err_to_name(esp_err));
-    esp_https_ota_finish(ota_handle);
+  esp_err = esp_ota_end(otaHandle);  // verifies the written image
+  if (esp_err != ESP_OK) {
+    LOG_ERR("OTA", "esp_ota_end failed: %s", esp_err_to_name(esp_err));
     return INTERNAL_UPDATE_ERROR;
   }
 
-  esp_err = esp_https_ota_finish(ota_handle);
+  esp_err = esp_ota_set_boot_partition(updatePartition);
   if (esp_err != ESP_OK) {
-    LOG_ERR("OTA", "esp_https_ota_finish Failed: %s", esp_err_to_name(esp_err));
+    LOG_ERR("OTA", "esp_ota_set_boot_partition failed: %s", esp_err_to_name(esp_err));
     return INTERNAL_UPDATE_ERROR;
   }
 

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <string>
 
 class OtaUpdater {
@@ -10,9 +9,10 @@ class OtaUpdater {
   size_t otaSize = 0;
   size_t processedSize = 0;
   size_t totalSize = 0;
-  bool render = false;
 
  public:
+  using ProgressCallback = void (*)(void* ctx);
+
   enum OtaUpdaterError {
     OK = 0,
     NO_UPDATE,
@@ -29,11 +29,9 @@ class OtaUpdater {
 
   size_t getTotalSize() const { return totalSize; }
 
-  bool getRender() const { return render; }
-
   OtaUpdater() = default;
   bool isUpdateNewer() const;
   const std::string& getLatestVersion() const;
   OtaUpdaterError checkForUpdate();
-  OtaUpdaterError installUpdate();
+  OtaUpdaterError installUpdate(ProgressCallback onProgress = nullptr, void* ctx = nullptr);
 };

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -9,6 +9,9 @@ class OtaUpdater {
   size_t otaSize = 0;
   size_t processedSize = 0;
   size_t totalSize = 0;
+  // 失敗ステップと esp_err_t の名前を短くまとめた診断文字列。
+  // シリアルが取れない環境で FAILED 画面に表示するため。
+  std::string lastErrorDetail;
 
  public:
   using ProgressCallback = void (*)(void* ctx);
@@ -28,6 +31,8 @@ class OtaUpdater {
   size_t getProcessedSize() const { return processedSize; }
 
   size_t getTotalSize() const { return totalSize; }
+
+  const std::string& getLastErrorDetail() const { return lastErrorDetail; }
 
   OtaUpdater() = default;
   bool isUpdateNewer() const;

--- a/src/platform/skip_efuse_blk_check.c
+++ b/src/platform/skip_efuse_blk_check.c
@@ -1,0 +1,11 @@
+// Override the prebuilt libbootloader_support.a implementation.
+// The X3's validation code misreads the new image's esp_app_desc_t through a
+// misaligned bootloader_mmap pointer, producing garbage eFuse block revision
+// values that fail the check. Safe to skip: the eFuse block revision gate is
+// a manufacturing concern, not a runtime safety issue.
+#include <esp_err.h>
+esp_err_t __wrap_bootloader_common_check_efuse_blk_validity(uint32_t min_rev_full, uint32_t max_rev_full) {
+  (void)min_rev_full;
+  (void)max_rev_full;
+  return ESP_OK;
+}

--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -2,8 +2,6 @@
 
 namespace UrlUtils {
 
-bool isHttpsUrl(const std::string& url) { return url.rfind("https://", 0) == 0; }
-
 std::string ensureProtocol(const std::string& url) {
   if (url.find("://") == std::string::npos) {
     return "http://" + url;

--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -1,6 +1,29 @@
 #include "UrlUtils.h"
 
+#include <cstdio>
+
 namespace UrlUtils {
+namespace {
+bool isHexDigit(const char c) { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
+
+bool shouldEncode(const unsigned char c) {
+  if (c <= 0x20 || c >= 0x7f) return true;
+  switch (c) {
+    case '"':
+    case '<':
+    case '>':
+    case '\\':
+    case '^':
+    case '`':
+    case '{':
+    case '|':
+    case '}':
+      return true;
+    default:
+      return false;
+  }
+}
+}  // namespace
 
 std::string ensureProtocol(const std::string& url) {
   if (url.find("://") == std::string::npos) {
@@ -22,18 +45,39 @@ std::string extractHost(const std::string& url) {
   return pathStart == std::string::npos ? url : url.substr(0, pathStart);
 }
 
+std::string encodeUnsafeUrlChars(const std::string& url) {
+  std::string out;
+  out.reserve(url.size());
+  for (size_t i = 0; i < url.size(); ++i) {
+    const unsigned char c = static_cast<unsigned char>(url[i]);
+    if (c == '%' && i + 2 < url.size() && isHexDigit(url[i + 1]) && isHexDigit(url[i + 2])) {
+      out += url[i];
+      out += url[i + 1];
+      out += url[i + 2];
+      i += 2;
+    } else if (c == '%' || shouldEncode(c)) {
+      char encoded[4];
+      snprintf(encoded, sizeof(encoded), "%%%02X", c);
+      out += encoded;
+    } else {
+      out += static_cast<char>(c);
+    }
+  }
+  return out;
+}
+
 std::string buildUrl(const std::string& serverUrl, const std::string& path) {
   // If path is already an absolute URL (has protocol), use it directly
   if (path.find("://") != std::string::npos) {
-    return path;
+    return encodeUnsafeUrlChars(path);
   }
   const std::string urlWithProtocol = ensureProtocol(serverUrl);
   if (path.empty()) {
-    return urlWithProtocol;
+    return encodeUnsafeUrlChars(urlWithProtocol);
   }
   if (path[0] == '/') {
     // Absolute path - use just the host
-    return extractHost(urlWithProtocol) + path;
+    return encodeUnsafeUrlChars(extractHost(urlWithProtocol) + path);
   }
   // Relative path - strip query string from base before appending
   std::string base = urlWithProtocol;
@@ -42,9 +86,9 @@ std::string buildUrl(const std::string& serverUrl, const std::string& path) {
     base.resize(queryPos);
   }
   if (base.back() == '/') {
-    return base + path;
+    return encodeUnsafeUrlChars(base + path);
   }
-  return base + "/" + path;
+  return encodeUnsafeUrlChars(base + "/" + path);
 }
 
 }  // namespace UrlUtils

--- a/src/util/UrlUtils.h
+++ b/src/util/UrlUtils.h
@@ -14,6 +14,11 @@ std::string ensureProtocol(const std::string& url);
 std::string extractHost(const std::string& url);
 
 /**
+ * Percent-encode raw characters that esp_http_client rejects in a URL.
+ */
+std::string encodeUnsafeUrlChars(const std::string& url);
+
+/**
  * Build full URL from server URL and path.
  * If path starts with /, it's an absolute path from the host root.
  * Otherwise, it's relative to the server URL.

--- a/src/util/UrlUtils.h
+++ b/src/util/UrlUtils.h
@@ -4,11 +4,6 @@
 namespace UrlUtils {
 
 /**
- * Check if URL uses HTTPS protocol
- */
-bool isHttpsUrl(const std::string& url);
-
-/**
  * Prepend http:// if no protocol specified (server will redirect to https if needed)
  */
 std::string ensureProtocol(const std::string& url);


### PR DESCRIPTION
## 概要

OTA アップデートが `ESP_ERR_OTA_VALIDATE_FAILED` で常に失敗する問題を修正し、v0.1.12 のリリース準備を行う。

## 根本原因（2つの独立した不具合）

1. **eFuse ブロックリビジョン検査のバグ**（本家 #1805 で修正済み、fork のベース v1.2.0 より後のため未取込）
   X3/X4 の検証コードがミスアラインされた `bootloader_mmap` ポインタ経由で `esp_app_desc_t` を読み、ゴミの eFuse リビジョン値で `esp_image_verify` が常に失敗する。linker の `--wrap` で当該検査をスキップ（eFuse リビジョンは製造上のゲートであり実行時安全性に影響しない）。

2. **HTTP TX バッファ不足によるリダイレクト先接続失敗**
   本家 release/1.5.0 の TX 512 bytes では、GitHub リリースの署名付き CDN URL（path+query 700-900 bytes）のリクエスト行が収まらない（本家は OTA を wolfSSL 側で行うため顕在化しない）。実績のある RX4096/TX1024 に戻した。

## 主な変更

- OTA install を本家 release/1.5.0 (#2475) の `esp_ota_begin/write/end` + `HttpDownloader::fetchUrl` ストリーミング方式に置き換え（wolfSSL はフラグ無効のため esp_http_client/mbedTLS のまま）
- `src/platform/skip_efuse_blk_check.c` + `--wrap=bootloader_common_check_efuse_blk_validity`（本家 #1805）
- OTA 失敗時に失敗段階・esp_err・ヒープ情報を画面表示する診断機能（シリアル不安定対策）
- `OTA_TEST_VERSION` 環境変数によるテストビルド用バージョン上書き
- v0.1.12 リリース準備（platformio.ini バージョン更新）

## 動作確認

- [x] `pio run -e default` ビルド成功
- [x] `bin/clang-format-fix` 差分なし
- [x] 実機 (X3) で OTA install 成功: 0.0.1-dev テストビルド → v0.1.11 検知 → ダウンロード → 検証通過 → 再起動して更新完了を確認
- [x] リリースアセットの整合性検証（image magic / 末尾 SHA-256 一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)