### PR TITLE
chore: リリースをActionsのボタン操作だけで完結できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -39,6 +42,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -62,6 +68,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,117 @@
+name: Release (dispatch)
+
+# Actions 画面から patch / minor / major を選んで実行すると、直近の v0.x.y タグから
+# 次のバージョンを算出してタグを打つ。タグの push を release.yml が拾って
+# ビルドと GitHub Release 作成を行うので、このワークフロー自体はビルドしない。
+#
+# これによりリリース作業は「Actions でボタンを押す」だけになる。
+# ローカルでの `git tag` / `git push --tags` は不要。
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'どこを上げるか'
+        required: true
+        type: choice
+        default: patch
+        options: [patch, minor, major]
+      prerelease:
+        description: 'RC としてリリースする (v0.1.13-rc1 のような形式になる)'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: '算出結果を表示するだけでタグは打たない'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # タグ計算に全履歴が要る
+          fetch-depth: 0
+
+      - name: Refuse to release from a non-default branch
+        if: github.ref_name != github.event.repository.default_branch
+        run: |
+          echo "::error::リリースは ${{ github.event.repository.default_branch }} からのみ実行できます (今回: ${{ github.ref_name }})"
+          exit 1
+
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+
+          # このブランチの祖先にあるタグだけを見る。fork 元由来のタグ (v0.2.x /
+          # v0.3.0 など) は master の祖先ではないので自然に除外される。
+          latest="$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || echo '')"
+          if [ -z "${latest}" ]; then
+            echo "::error::v*.*.* 形式のタグが見つかりません。最初のタグは手動で作成してください。"
+            exit 1
+          fi
+
+          base="${latest#v}"
+          # RC サフィックスを落として素の x.y.z にする
+          base="${base%%-*}"
+          IFS='.' read -r major minor patch <<< "${base}"
+
+          case "${{ inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+
+          next="v${major}.${minor}.${patch}"
+
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            # 同じ x.y.z の既存 RC を数えて連番にする
+            n=1
+            while git rev-parse -q --verify "refs/tags/${next}-rc${n}" >/dev/null; do
+              n=$((n + 1))
+            done
+            next="${next}-rc${n}"
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${next}" >/dev/null; then
+            echo "::error::タグ ${next} は既に存在します"
+            exit 1
+          fi
+
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+          echo "next=${next}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### リリース"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| 直近のタグ | \`${latest}\` |"
+            echo "| 新しいタグ | \`${next}\` |"
+            echo "| bump | ${{ inputs.bump }} |"
+            echo "| commit | \`$(git rev-parse --short HEAD)\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create and push tag
+        if: inputs.dry_run != true
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.next }}" \
+            -m "${{ steps.version.outputs.next }}"
+          git push origin "${{ steps.version.outputs.next }}"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "タグを push しました。release.yml がビルドと Release 作成を行います。" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry run notice
+        if: inputs.dry_run == true
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**dry run のためタグは作成していません。**" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -27,12 +30,8 @@ jobs:
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
-      - name: Sync version from tag
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-          sed -i "s/^version = .*/version = ${VERSION}/" platformio.ini
-          echo "Building with version: ${VERSION}"
+      # platformio.ini に version を書き戻すステップは不要になった。
+      # scripts/git_branch.py が git tag から直接 CROSSPOINT_VERSION を決める。
 
       - name: Build CrossPoint
         run: |

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          # scripts/git_branch.py derives CROSSPOINT_VERSION with `git describe`,
+          # which needs the tags and enough history to reach them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,57 @@
+# リリース手順
+
+## リリースする
+
+GitHub の **Actions → Release (dispatch) → Run workflow** から実行する。ローカルでの `git tag` / `git push --tags` は不要。
+
+| 入力 | 説明 |
+|------|------|
+| `bump` | `patch` / `minor` / `major`。直近の `v*` タグから次の番号を算出する |
+| `prerelease` | RC としてリリースする。`v0.1.13-rc1` のような連番になる |
+| `dry_run` | 算出結果をサマリに出すだけで、タグは打たない |
+
+タグが push されると `release.yml` が発火し、ビルドと GitHub Release の作成まで自動で進む。
+
+実行前に対象コミットが `master` にマージ済みであること。`master` 以外のブランチからの実行はワークフロー側で拒否される。
+
+## バージョンの決まり方
+
+**git tag が唯一の情報源**で、`platformio.ini` にバージョンは書かれていない。`scripts/git_branch.py` が全環境の `CROSSPOINT_VERSION` を組み立てる。
+
+| ビルド | バージョン文字列 | 意味 |
+|--------|------------------|------|
+| リリース（タグ上） | `0.1.13` | `v0.1.13` そのもの |
+| リリース（タグ外） | `0.1.12-15-g173ad08b` | v0.1.12 から 15 コミット進んだ地点のビルド |
+| dev (`env:default`) | `0.1.12-dev-my-branch-173ad08b` | ブランチ名と commit 付き |
+
+タグ外のリリースビルドに `-15-g173ad08b` が付くのは意図的で、手元でうっかり作った成果物が正規リリースと見分けられなくなるのを防ぐため。
+
+`build_flags` で `CROSSPOINT_VERSION` を定義した環境はその値を維持する。OTA の検証で特定バージョンを名乗らせたい場合は `platformio.local.ini`（gitignore 済み）で上書きする。
+
+```ini
+[env:ota_rc_test]
+extends = base
+build_flags =
+  ${base.build_flags}
+  -DCROSSPOINT_VERSION=\"0.1.12-rc1\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1
+custom_i18n_languages = ENGLISH, JAPANESE
+```
+
+`-rc` を含むバージョンは `OtaUpdater::isUpdateNewer()` が同一バージョン番号でも「更新あり」と判定するため（`src/network/OtaUpdater.cpp`）、GitHub に新しいリリースを作らずに OTA のダウンロード経路を検証できる。
+
+## 注意点
+
+**CI のチェックアウトには `fetch-depth: 0` が必要。** バージョンは `git describe` で求めるので、浅いクローンではタグに到達できず `0.0.0` になる。ビルドを行うワークフローには設定済み。
+
+**fork 由来のタグを持ち込まない。** `--match 'v[0-9]*'` で絞ったうえで、`git describe` は HEAD の祖先しか見ないため通常は問題にならない。過去に cjk-fork 由来の `v0.2.x` / `v0.3.0` が混入していたが削除済み。
+
+## 関連ワークフロー
+
+| ファイル | 契機 | 用途 |
+|----------|------|------|
+| `release-dispatch.yml` | 手動 | バージョン算出とタグ作成 |
+| `release.yml` | タグ push | ビルドと Release 作成 |
+| `release_candidate.yml` | 手動（`release/*` ブランチ） | RC ビルド |
+| `dev-build.yml` | master への push | Dev Build のプレリリース |

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,8 +3,9 @@ default_envs = default
 build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
-[crosspoint]
-version = 0.1.12
+; バージョンはここでは持たない。git tag が唯一の情報源で、
+; scripts/git_branch.py が全環境の CROSSPOINT_VERSION を組み立てる。
+; リリースは Actions の "Release (dispatch)" から実行する。
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
@@ -133,7 +134,7 @@ custom_i18n_languages = ENGLISH, JAPANESE
 extends = base
 build_flags =
   ${base.build_flags}
-  -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
+  ; CROSSPOINT_VERSION is set by scripts/git_branch.py from the git tag
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
 custom_i18n_languages = ENGLISH, JAPANESE

--- a/scripts/git_branch.py
+++ b/scripts/git_branch.py
@@ -1,12 +1,18 @@
 """
-PlatformIO pre-build script: inject git branch and short SHA into
-CROSSPOINT_VERSION for the default (dev) environment.
+PlatformIO pre-build script: derive CROSSPOINT_VERSION from git tags.
 
-Results in a version string like:  1.1.0-dev-feat-kosync-xpath-05c6cf8
-Release environments are unaffected; they set CROSSPOINT_VERSION in the ini.
+Git tags are the single source of truth for the version — platformio.ini does
+not carry one. Releases are cut by tagging (see .github/workflows/
+release-dispatch.yml), so there is no version to keep in sync by hand.
+
+    release env, on a tag   1.2.3
+    release env, off-tag    1.2.3-4-gabc1234      (4 commits past v1.2.3)
+    dev env                 1.2.3-dev-my-branch-abc1234
+
+An environment that sets CROSSPOINT_VERSION in build_flags keeps its own value;
+platformio.local.ini uses that to pin a version for OTA testing.
 """
 
-import configparser
 import os
 import subprocess
 import sys
@@ -63,12 +69,26 @@ def get_git_short_sha(project_dir):
     )
 
 
-def get_version_from_git_tag(project_dir):
-    """Try to derive version from the latest v* git tag (e.g. v0.1.3 → 0.1.3)."""
+def get_version_from_git_tag(project_dir, exact=False, bare=False):
+    """Derive the version from git tags. Git tags are the single source of truth.
+
+    exact=True returns a version only when HEAD sits exactly on a release tag
+    (v1.2.3 -> 1.2.3), and None otherwise.
+    bare=True returns just the nearest tag (1.2.3); otherwise git describe
+    appends distance and commit (1.2.3-4-gabc1234), marking the build as "4
+    commits past v1.2.3" rather than letting it pass for the release itself.
+
+    Only v<digit>* is matched, so tags inherited from other forks cannot be
+    picked up (they are not ancestors of this branch either).
+    """
+    args = ['describe', '--tags', '--match', 'v[0-9]*']
+    if exact:
+        args.append('--exact-match')
+    elif bare:
+        args.append('--abbrev=0')
     try:
         tag = subprocess.check_output(
-            ['git', 'describe', '--tags', '--match', 'v*', '--abbrev=0'],
-            text=True, stderr=subprocess.PIPE, cwd=project_dir
+            ['git', *args], text=True, stderr=subprocess.PIPE, cwd=project_dir
         ).strip()
         version = tag.lstrip('v')
         if version:
@@ -78,41 +98,50 @@ def get_version_from_git_tag(project_dir):
     return None
 
 
-def get_base_version(project_dir):
+def get_base_version(project_dir, bare=False):
     # Env var override (OTA test / debug): highest priority
     override = os.environ.get('OTA_TEST_VERSION')
     if override:
         return override
 
-    # Prefer version from latest git tag (single source of truth)
-    git_version = get_version_from_git_tag(project_dir)
+    git_version = get_version_from_git_tag(project_dir, bare=bare)
     if git_version:
         return git_version
 
-    # Fall back to platformio.ini (for repos without tags)
-    ini_path = os.path.join(project_dir, 'platformio.ini')
-    if not os.path.isfile(ini_path):
-        warn(f'platformio.ini not found at {ini_path}; base version will be "0.0.0"')
-        return '0.0.0'
-    config = configparser.ConfigParser()
-    config.read(ini_path)
-    if not config.has_option('crosspoint', 'version'):
-        warn('No [crosspoint] version in platformio.ini; base version will be "0.0.0"')
-        return '0.0.0'
-    return config.get('crosspoint', 'version')
+    # No tags reachable (shallow clone, fresh fork). platformio.ini no longer
+    # carries a version, so there is nothing left to fall back to.
+    warn('No v* git tag reachable from HEAD; base version will be "0.0.0"')
+    return '0.0.0'
 
 
 def inject_version(env):
-    # Only applies to the dev (default) environment; release envs set the
-    # version via build_flags in platformio.ini and are unaffected.
-    if env['PIOENV'] != 'default':
-        return
+    # Every environment gets its version from here. An env that already defines
+    # CROSSPOINT_VERSION in build_flags (e.g. an OTA test build pinning
+    # "0.1.12-rc1") keeps that value.
+    for define in env.get('CPPDEFINES', []):
+        name = define[0] if isinstance(define, (list, tuple)) else define
+        if name == 'CROSSPOINT_VERSION':
+            return
 
     project_dir = env['PROJECT_DIR']
-    base_version = get_base_version(project_dir)
-    branch = get_git_branch(project_dir)
-    short_sha = get_git_short_sha(project_dir)
-    version_string = f'{base_version}-dev-{branch}-{short_sha}'
+
+    if env['PIOENV'] == 'default':
+        # Dev build: base version plus branch and commit, so a firmware built
+        # from a feature branch is never mistaken for a release. The branch and
+        # SHA already say where the build came from, so use the bare tag name
+        # rather than git describe's "-<distance>-g<sha>" suffix.
+        base_version = get_base_version(project_dir, bare=True)
+        branch = get_git_branch(project_dir)
+        short_sha = get_git_short_sha(project_dir)
+        version_string = f'{base_version}-dev-{branch}-{short_sha}'
+    else:
+        # Release build. On a release tag this is exactly "1.2.3"; off-tag,
+        # git describe appends the distance and commit ("1.2.3-4-gabc1234") so
+        # an ad-hoc release build is distinguishable from the real release.
+        version_string = (
+            get_version_from_git_tag(project_dir, exact=True)
+            or get_base_version(project_dir)
+        )
 
     env.Append(CPPDEFINES=[('CROSSPOINT_VERSION', f'\\"{version_string}\\"')])
     print(f'CrossPoint build version: {version_string}')


### PR DESCRIPTION
## 背景

リリース手順が「master にマージ → `platformio.ini` を更新 → タグを push」と認識されており、煩雑という声があった。

調べたところ **`platformio.ini` の更新は既に不要**だった。`release.yml` にタグからバージョンを同期するステップがあり、手で書き換えても CI が上書きしていた。

```bash
# release.yml (削除前)
TAG="${GITHUB_REF_NAME}"
VERSION="${TAG#v}"
sed -i "s/^version = .*/version = ${VERSION}/" platformio.ini
```

さらに `scripts/git_branch.py` も既にタグを優先しており、ini の `version = 0.1.12` は**実質どこからも正として使われていない**状態だった。煩雑さの実体は「どこが正なのか分からない」ことだったと考えられる。

## 変更内容

### 1. Actions からボタン一つでリリース

`.github/workflows/release-dispatch.yml` を新設。**Actions → Release (dispatch) → Run workflow** で `patch`/`minor`/`major` を選ぶだけでリリースできる。

直近の `v*` タグから次の番号を算出してタグを push し、既存の `release.yml` がそれを拾ってビルドと Release 作成まで進む。ローカルでの `git tag` / `git push --tags` は不要になり、次の番号を自分で調べる手間もなくなる。

- `dry_run`: タグを打たずに算出結果だけ確認できる
- `prerelease`: `v0.1.13-rc1` 形式の連番 RC を作れる
- `master` 以外のブランチからの実行は拒否する

### 2. バージョンの情報源を git tag に一本化

`platformio.ini` の `[crosspoint] version` と `release.yml` の同期ステップを削除し、`scripts/git_branch.py` を唯一の情報源にした。

| ビルド | バージョン文字列 |
|---|---|
| リリース（タグ上） | `0.1.13` |
| リリース（タグ外） | `0.1.12-15-g173ad08b` |
| dev | `0.1.12-dev-my-branch-173ad08b` |

タグ外のリリースビルドに距離と commit が付くのは意図的で、手元でうっかり作った成果物が正規リリースと見分けられなくなるのを防ぐ。

`build_flags` で `CROSSPOINT_VERSION` を定義した環境はその値を維持する（`platformio.local.ini` で OTA テスト用に固定する用途を壊さないため）。

`git describe` を使うので、ビルドを行う全ワークフローの checkout に `fetch-depth: 0` を追加した。浅いクローンではタグに到達できず `0.0.0` になってしまう。

### 3. ドキュメント追加

`docs/releasing.md` にリリース手順とバージョンの決まり方を記載した。

## 付随して実施したこと

cjk-fork 由来のタグ `v0.2.0` / `v0.2.1` / `v0.2.2` / `v0.3.0` を削除した（GitHub Release は紐付いていなかった）。このリポジトリのリリース体系は `v0.1.x` 系列で、これらが `git describe` に拾われると誤ったバージョンになりうるため。

なお `v0.1.0`〜`v0.1.5` も `master` の祖先ではないが、日本語のコミットメッセージを持ち `v0.1.3`/`v0.1.4` には GitHub Release も存在することから**このフォーク自身のリリース**と判断して残した（履歴の作り直しで祖先関係が切れたと見られる）。

## 検証

- `pio run`（default / gh_release）: SUCCESS
- `pio check`（cppcheck）: No defects found
- 全ワークフロー YAML の構文検証: OK
- バージョン算出を実ビルドで確認:
  - dev → `0.1.12-dev-chore/release-flow-173ad08b`
  - gh_release（タグ外）→ `0.1.12-15-g173ad08b`
  - `--exact-match` が `v0.1.12` を返すことを確認（タグ上では `0.1.12` になる）
  - `build_flags` 定義済みの環境で上書きされないことを確認

OTA のバージョン比較（`parseSemver3`）は `sscanf("%d.%d.%d")` で先頭 3 セグメントのみ読むため、`-15-g...` が付いても影響しない。

## マージ後の確認をおすすめしたいこと

`release-dispatch.yml` は `dry_run: true` で一度実行すると、タグを作らずに算出結果（`v0.1.12` → `v0.1.13`）をサマリで確認できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)