### PR TITLE
fix: dispatch リリースで release.yml が起動しない問題を修正

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,8 +1,8 @@
 name: Release (dispatch)
 
 # Actions 画面から patch / minor / major を選んで実行すると、直近の v0.x.y タグから
-# 次のバージョンを算出してタグを打つ。タグの push を release.yml が拾って
-# ビルドと GitHub Release 作成を行うので、このワークフロー自体はビルドしない。
+# 次のバージョンを算出してタグを打ち、release.yml を起動する。ビルドと
+# GitHub Release 作成は release.yml 側の仕事なので、このワークフロー自体はビルドしない。
 #
 # これによりリリース作業は「Actions でボタンを押す」だけになる。
 # ローカルでの `git tag` / `git push --tags` は不要。
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # release.yml を workflow_dispatch で起動するのに必要
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -107,8 +109,31 @@ jobs:
           git tag -a "${{ steps.version.outputs.next }}" \
             -m "${{ steps.version.outputs.next }}"
           git push origin "${{ steps.version.outputs.next }}"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "タグを push しました。release.yml がビルドと Release 作成を行います。" >> "$GITHUB_STEP_SUMMARY"
+
+      # GITHUB_TOKEN で push したタグは push イベントを発生させない（ワークフローの
+      # 無限ループを防ぐための GitHub 側の仕様）ため、release.yml の
+      # `on: push: tags` は発火しない。workflow_dispatch と repository_dispatch は
+      # この制限の例外なので、タグ ref を指定して明示的に起動する。
+      # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+      - name: Trigger release build
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+          # push 直後は API 側でタグ ref がまだ見えないことがあるのでリトライする
+          for attempt in 1 2 3 4 5; do
+            if gh workflow run release.yml --ref "${TAG}"; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "タグ \`${TAG}\` を push し、release.yml を起動しました。ビルドと Release 作成はそちらで進みます。" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "release.yml の起動に失敗しました (${attempt}/5)。再試行します。"
+            sleep 5
+          done
+          echo "::error::release.yml の起動に失敗しました。タグ ${TAG} は作成済みなので、Actions から Compile Release をこのタグで手動実行してください。"
+          exit 1
 
       - name: Dry run notice
         if: inputs.dry_run == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,14 @@ on:
   push:
     tags:
       - '*'
+  # release-dispatch.yml がタグ ref を指定して起動する。GITHUB_TOKEN で push した
+  # タグは push イベントを発生させないため、上の push トリガーだけでは足りない。
+  workflow_dispatch:
 
 jobs:
   build-release:
+    # タグ以外の ref で誤って dispatch された場合に Release を作らないためのガード。
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,7 +10,7 @@ GitHub の **Actions → Release (dispatch) → Run workflow** から実行す�
 | `prerelease` | RC としてリリースする。`v0.1.13-rc1` のような連番になる |
 | `dry_run` | 算出結果をサマリに出すだけで、タグは打たない |
 
-タグが push されると `release.yml` が発火し、ビルドと GitHub Release の作成まで自動で進む。
+タグを push したあと `release-dispatch.yml` が `release.yml` を起動し、ビルドと GitHub Release の作成まで自動で進む。
 
 実行前に対象コミットが `master` にマージ済みであること。`master` 以外のブランチからの実行はワークフロー側で拒否される。
 
@@ -45,13 +45,15 @@ custom_i18n_languages = ENGLISH, JAPANESE
 
 **CI のチェックアウトには `fetch-depth: 0` が必要。** バージョンは `git describe` で求めるので、浅いクローンではタグに到達できず `0.0.0` になる。ビルドを行うワークフローには設定済み。
 
+**`GITHUB_TOKEN` で push したタグは `on: push: tags` を発火させない。** ワークフローの無限ループを防ぐための GitHub の仕様。このため `release-dispatch.yml` はタグを push したあと `gh workflow run release.yml --ref <タグ>` で `release.yml` を明示的に起動している（`workflow_dispatch` はこの制限の例外）。`release.yml` 側にも `workflow_dispatch` トリガーと、タグ以外の ref を弾く `if: startsWith(github.ref, 'refs/tags/')` ガードが必要。
+
 **fork 由来のタグを持ち込まない。** `--match 'v[0-9]*'` で絞ったうえで、`git describe` は HEAD の祖先しか見ないため通常は問題にならない。過去に cjk-fork 由来の `v0.2.x` / `v0.3.0` が混入していたが削除済み。
 
 ## 関連ワークフロー
 
 | ファイル | 契機 | 用途 |
 |----------|------|------|
-| `release-dispatch.yml` | 手動 | バージョン算出とタグ作成 |
-| `release.yml` | タグ push | ビルドと Release 作成 |
+| `release-dispatch.yml` | 手動 | バージョン算出、タグ作成、`release.yml` の起動 |
+| `release.yml` | タグ push または `release-dispatch.yml` からの起動 | ビルドと Release 作成 |
 | `release_candidate.yml` | 手動（`release/*` ブランチ） | RC ビルド |
 | `dev-build.yml` | master への push | Dev Build のプレリリース |


### PR DESCRIPTION
## 背景

Actions から **Release (dispatch)** を実行すると、タグは作られるがビルドと GitHub Release の作成が行われない不具合があった。

実際に v0.1.13 で発生している（[run #30668106084](https://github.com/zrn-ns/crosspoint-jp/actions/runs/30668106084) は success、タグ `v0.1.13` も存在するが、`Compile Release` は未実行、Release も未作成）。

## 原因

`release-dispatch.yml` の `Create and push tag` は `actions/checkout` が設定したデフォルトの `GITHUB_TOKEN` でタグを push している。ワークフローの無限ループを防ぐ GitHub の仕様により、この push はイベントを発生させないため、`release.yml` の `on: push: tags` が発火しない。

> With the exception of `workflow_dispatch` and `repository_dispatch`, other `GITHUB_TOKEN`-triggered events do not create workflow runs at all.
> — [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)

## 変更内容

- `release-dispatch.yml`: タグ push 後に `gh workflow run release.yml --ref <タグ>` で `release.yml` を明示的に起動する。上記の通り `workflow_dispatch` は制限の例外なので、PAT を Secrets に置かずに済む。
  - API 側でタグ ref が見えるまで数秒かかることがあるため 5 回リトライする。
  - 全て失敗した場合はタグが作成済みであることと手動での復旧手順をエラーメッセージに出す。
  - `permissions` に `actions: write` を追加。
- `release.yml`: `workflow_dispatch` トリガーを追加。タグ以外の ref で誤って dispatch された場合に Release を作らないよう `if: startsWith(github.ref, 'refs/tags/')` でガード。
- `docs/releasing.md`: 上記の仕様と対処を注意点に追記。

## 確認したこと

- [x] 両ワークフローの YAML が構文エラーなくパースできる
- [x] `git diff` で意図しない変更が含まれていないことを確認
- [x] シークレット未混入（追加したのは `secrets.GITHUB_TOKEN` の参照のみ）
- [x] `Deploy Flasher` は `workflow_run: workflows: ["Compile Release"]` で連鎖しており、この変更でもワークフロー名は変わらない

C++ ソースは変更していないためファームウェアの挙動には影響しない。

## 残る確認

- [ ] マージ後に **Release (dispatch)** を実行し、`Compile Release` が自動で起動して Release が作成されることを確認する（v0.1.14 で検証予定）

なお v0.1.13 のタグは残しているため、次の `patch` bump は v0.1.14 になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)