### PR TITLE
fix: dispatch リリースで Deploy Flasher が連鎖しない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Deploy Flasher を workflow_dispatch で起動するのに必要
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -94,3 +96,27 @@ jobs:
           prerelease: ${{ contains(github.ref, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # この run が release-dispatch.yml から workflow_dispatch で起動された場合、
+      # run 自体が GITHUB_TOKEN 由来なので完了時に workflow_run イベントが発生せず、
+      # deploy-flasher.yml の `workflow_run: workflows: ["Compile Release"]` が連鎖しない。
+      # そのため Web Flasher のマニフェストが古いリリースを指したままになる。
+      # タグ push で起動された場合は通常どおり連鎖するので、その場合は何もしない。
+      - name: Trigger flasher deployment
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # workflow_run で起動されたときと同じ ref を使う
+          REF: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if gh workflow run deploy-flasher.yml --ref "${REF}"; then
+              echo "Deploy Flasher を起動しました。"
+              exit 0
+            fi
+            echo "Deploy Flasher の起動に失敗しました (${attempt}/3)。再試行します。"
+            sleep 5
+          done
+          echo "::error::Deploy Flasher の起動に失敗しました。Release は作成済みなので、Actions から Deploy Flasher を手動実行してください。"
+          exit 1

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -45,7 +45,14 @@ custom_i18n_languages = ENGLISH, JAPANESE
 
 **CI のチェックアウトには `fetch-depth: 0` が必要。** バージョンは `git describe` で求めるので、浅いクローンではタグに到達できず `0.0.0` になる。ビルドを行うワークフローには設定済み。
 
-**`GITHUB_TOKEN` で push したタグは `on: push: tags` を発火させない。** ワークフローの無限ループを防ぐための GitHub の仕様。このため `release-dispatch.yml` はタグを push したあと `gh workflow run release.yml --ref <タグ>` で `release.yml` を明示的に起動している（`workflow_dispatch` はこの制限の例外）。`release.yml` 側にも `workflow_dispatch` トリガーと、タグ以外の ref を弾く `if: startsWith(github.ref, 'refs/tags/')` ガードが必要。
+**`GITHUB_TOKEN` 由来のイベントはワークフローを起動しない。** ワークフローの無限ループを防ぐための GitHub の仕様で、`workflow_dispatch` と `repository_dispatch` だけが例外。リリースの連鎖はこれに二度引っかかるため、いずれも `gh workflow run` で明示的に起動している。
+
+| 連鎖 | 本来の契機 | 発火しない理由 | 対処 |
+|------|------------|----------------|------|
+| `release-dispatch.yml` → `release.yml` | タグ push | `GITHUB_TOKEN` で push したタグは push イベントを発生させない | `gh workflow run release.yml --ref <タグ>` |
+| `release.yml` → `deploy-flasher.yml` | `workflow_run` | `release.yml` の run 自体が `GITHUB_TOKEN` 由来なので完了時に `workflow_run` が発生しない | `gh workflow run deploy-flasher.yml --ref master` |
+
+そのため `release.yml` には `workflow_dispatch` トリガー、タグ以外の ref を弾く `if: startsWith(github.ref, 'refs/tags/')` ガード、`actions: write` 権限が必要。後者の連鎖は `github.event_name == 'workflow_dispatch'` のときだけ起動する（タグ push 経由なら `workflow_run` が通常どおり連鎖するため）。
 
 **fork 由来のタグを持ち込まない。** `--match 'v[0-9]*'` で絞ったうえで、`git describe` は HEAD の祖先しか見ないため通常は問題にならない。過去に cjk-fork 由来の `v0.2.x` / `v0.3.0` が混入していたが削除済み。
 


### PR DESCRIPTION
## 背景

#92 で `Release (dispatch)` → `Compile Release` の連鎖は直り、v0.1.14 のビルドと Release 作成は成功した（[run 30670332709](https://github.com/zrn-ns/crosspoint-jp/actions/runs/30670332709)）。

しかし **`Deploy Flasher` が連鎖していない**。3分以上待って確認したが、最新の `Deploy Flasher` は 7/31 15:01 のままで、gh-pages の `manifest_stable.json` は依然 `v0.1.12` を指している。

```
$ gh api "repos/zrn-ns/crosspoint-jp/contents/manifest_stable.json?ref=gh-pages" ... 
flasher stable version: v0.1.12
```

つまり Web Flasher から書き込めるのは v0.1.12 のままで、v0.1.14 が配布されていない。

## 原因

#92 と同じ `GITHUB_TOKEN` の制約が一段下でも効いている。

`release.yml` の run 自体が `workflow_dispatch`（`GITHUB_TOKEN` 経由）で起動されているため、その完了時に `workflow_run` イベントが発生せず、`deploy-flasher.yml` の `workflow_run: workflows: ["Compile Release"]` が拾えない。

参考: v0.1.12（人間がタグを push した回）では `Compile Release` 完了の 7 秒後に `Deploy Flasher` が走っており、タグ ref 由来であること自体は連鎖の妨げになっていない。差分は起動経路だけ。

## 変更内容

- `release.yml`: Release 作成後に `gh workflow run deploy-flasher.yml --ref <default branch>` で明示的に起動（3回リトライ）。`permissions` に `actions: write` を追加。
  - `if: github.event_name == 'workflow_dispatch'` を付けているので、タグを直接 push した場合は従来どおり `workflow_run` に任せ、二重起動しない。
  - `--ref` は `github.event.repository.default_branch`。`workflow_run` で起動されたときの checkout 対象（デフォルトブランチ）と揃えている。
- `docs/releasing.md`: 2箇所の連鎖と対処を表にまとめた。

## 確認したこと

- [x] `release.yml` の YAML が構文エラーなくパースでき、`Trigger flasher deployment` の `if` が意図どおり付いている
- [x] `git diff` で意図しない変更が含まれていないことを確認
- [x] シークレット未混入（追加したのは `secrets.GITHUB_TOKEN` の参照のみ）
- [x] `deploy-flasher.yml` は `workflow_dispatch` トリガーを既に持っており、`if` 条件（`github.event_name == 'workflow_dispatch'`）も dispatch を許可している

C++ ソースは変更していないためファームウェアの挙動には影響しない。

## 残る作業

- [ ] v0.1.14 を Web Flasher に反映するため、**Deploy Flasher を一度手動実行する**（この PR は次回以降のリリースを自動化するもので、既に作成済みの v0.1.14 は救済しない）
- [ ] 次回リリース時に `Deploy Flasher` が自動で連鎖することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)