### PR TITLE
fix: フォントダウンロード機能が接続段階で失敗する問題を修正

### DIFF
--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -80,6 +80,7 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   // This avoids holding both TLS buffers and manifest data in RAM.
   static constexpr const char* MANIFEST_TMP = "/fonts_manifest.tmp";
 
+  errorDetail_.clear();  // don't let a previous failure's diagnostics linger
   const size_t heapBefore = ESP.getFreeHeap();
   // LARGE buffers: the manifest lives on a GitHub release, which redirects to a
   // signed release-assets.githubusercontent.com URL ~860 bytes long. That request
@@ -202,6 +203,7 @@ size_t FontDownloadActivity::totalUninstalledSize() const {
 void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
   {
     RenderLock lock(*this);
+    errorDetail_.clear();  // don't let a previous failure's diagnostics linger
     state_ = DOWNLOADING;
     downloadingFamilyIndex_ = static_cast<int>(&family - families_.data());
     currentFileIndex_ = 0;
@@ -234,11 +236,20 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
 
     std::string url = baseUrl_ + file.name;
 
+    // Fire the render task only on whole-percent change. HttpDownloader reads in
+    // 1KB chunks, so a per-chunk update would wake the render task ~400 times for
+    // a single font file; that framebuffer work contends with TLS on the internal
+    // arena and e-ink cannot repaint faster than a percent tick anyway. Same
+    // reasoning as the OTA download — see OtaUpdater::installUpdate.
+    int lastReportedPct = -1;
     // LARGE buffers for the same reason as the manifest fetch: the signed
     // redirect target runs ~900 bytes for the longest font file name.
     auto result = HttpDownloader::downloadToFile(
         url, destPath,
-        [this](size_t downloaded, size_t total) {
+        [this, &lastReportedPct](size_t downloaded, size_t total) {
+          const int pct = total > 0 ? static_cast<int>(static_cast<uint64_t>(downloaded) * 100 / total) : 0;
+          if (pct == lastReportedPct) return;
+          lastReportedPct = pct;
           fileProgress_ = downloaded;
           fileTotal_ = total;
           requestUpdate(true);
@@ -246,10 +257,21 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
         nullptr, "", "", HttpDownloader::BufferProfile::LARGE);
 
     if (result != HttpDownloader::OK) {
-      LOG_ERR("FONT", "Download failed: %s (%d)", file.name.c_str(), result);
+      LOG_ERR("FONT", "Download failed: %s err=%d http=%d heap=%d blk=%d got=%zu", file.name.c_str(),
+              static_cast<int>(result), HttpDownloader::lastHttpCode, static_cast<int>(ESP.getFreeHeap()),
+              static_cast<int>(ESP.getMaxAllocHeap()), fileProgress_);
+      char buf[80];
+      // Same diagnostics as the manifest fetch: err is DownloadError, http is
+      // either an HTTP status or a negated esp_err_t, and blk is the largest
+      // contiguous block (a TLS handshake needs ~45-55KB of it). got is how far
+      // the transfer got before it died, rounded to the last whole percent.
+      snprintf(buf, sizeof(buf), "err=%d http=%d heap=%dKB blk=%dKB got=%dKB", static_cast<int>(result),
+               HttpDownloader::lastHttpCode, static_cast<int>(ESP.getFreeHeap() / 1024),
+               static_cast<int>(ESP.getMaxAllocHeap() / 1024), static_cast<int>(fileProgress_ / 1024));
       RenderLock lock(*this);
       state_ = ERROR;
       errorMessage_ = "Download failed: " + file.name;
+      errorDetail_ = buf;
       return;
     }
 
@@ -457,6 +479,9 @@ void FontDownloadActivity::render(RenderLock&&) {
                               EpdFontFamily::BOLD);
     if (!errorMessage_.empty()) {
       renderer.drawCenteredText(UI_10_FONT_ID, centerY + metrics.verticalSpacing, errorMessage_.c_str());
+    }
+    if (!errorDetail_.empty()) {
+      renderer.drawCenteredText(UI_10_FONT_ID, centerY + metrics.verticalSpacing + lineHeight, errorDetail_.c_str());
     }
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -122,38 +122,52 @@ bool FontDownloadActivity::fetchAndParseManifest() {
     return false;
   }
 
-  baseUrl_ = doc["baseUrl"] | "";
+  snprintf(baseUrl_, sizeof(baseUrl_), "%s", doc["baseUrl"] | "");
   families_.clear();
+  allFiles_.clear();
 
   JsonArray familiesArr = doc["families"].as<JsonArray>();
   families_.reserve(familiesArr.size());
 
+  // Count the files up front so allFiles_ is reserved exactly. Walking the
+  // JsonArray twice is far cheaper than the reallocate-copy-free cycles a
+  // growing vector would inflict on an already tight arena. The manifest's
+  // "styles" array is deliberately ignored: it is empty for every family and
+  // nothing reads it.
+  size_t fileCountTotal = 0;
+  for (JsonObject fObj : familiesArr) fileCountTotal += fObj["files"].as<JsonArray>().size();
+  allFiles_.reserve(fileCountTotal);
+
   for (JsonObject fObj : familiesArr) {
     ManifestFamily family;
-    family.name = fObj["name"] | "";
-    family.description = fObj["description"] | "";
+    snprintf(family.name, sizeof(family.name), "%s", fObj["name"] | "");
+    snprintf(family.description, sizeof(family.description), "%s", fObj["description"] | "");
 
-    for (JsonVariant s : fObj["styles"].as<JsonArray>()) {
-      family.styles.push_back(s.as<std::string>());
-    }
-
+    family.fileStart = static_cast<uint16_t>(allFiles_.size());
+    family.fileCount = 0;
     family.totalSize = 0;
     for (JsonObject fileObj : fObj["files"].as<JsonArray>()) {
+      if (family.fileCount == UINT8_MAX) {
+        LOG_ERR("FONT", "Too many files in family %s; ignoring the rest", family.name);
+        break;
+      }
       ManifestFile file;
-      file.name = fileObj["name"] | "";
-      file.size = fileObj["size"] | 0;
+      snprintf(file.name, sizeof(file.name), "%s", fileObj["name"] | "");
+      file.size = fileObj["size"] | 0u;
       family.totalSize += file.size;
-      family.files.push_back(std::move(file));
+      allFiles_.push_back(file);
+      family.fileCount++;
     }
 
-    family.installed = fontInstaller_.isFamilyInstalled(family.name.c_str());
+    family.installed = fontInstaller_.isFamilyInstalled(family.name);
 
     // Detect updates by comparing manifest file sizes with files on disk.
     // Not a checksum, but a size mismatch reliably indicates a rebuild in practice.
     if (family.installed) {
-      for (const auto& file : family.files) {
+      for (uint8_t i = 0; i < family.fileCount; i++) {
+        const auto& file = allFiles_[family.fileStart + i];
         char path[128];
-        FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), path, sizeof(path));
+        FontInstaller::buildFontPath(family.name, file.name, path, sizeof(path));
         FsFile f;
         if (Storage.openFileForRead("FONT", path, f)) {
           size_t actual = f.fileSize();
@@ -207,21 +221,21 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
     state_ = DOWNLOADING;
     downloadingFamilyIndex_ = static_cast<int>(&family - families_.data());
     currentFileIndex_ = 0;
-    currentFileTotal_ = family.files.size();
+    currentFileTotal_ = family.fileCount;
     fileProgress_ = 0;
     fileTotal_ = 0;
   }
   requestUpdateAndWait();
 
-  if (!fontInstaller_.ensureFamilyDir(family.name.c_str())) {
+  if (!fontInstaller_.ensureFamilyDir(family.name)) {
     RenderLock lock(*this);
     state_ = ERROR;
     errorMessage_ = "Failed to create font directory";
     return;
   }
 
-  for (size_t i = 0; i < family.files.size(); i++) {
-    const auto& file = family.files[i];
+  for (uint8_t i = 0; i < family.fileCount; i++) {
+    const auto& file = allFiles_[family.fileStart + i];
 
     {
       RenderLock lock(*this);
@@ -232,9 +246,13 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
     requestUpdateAndWait();
 
     char destPath[128];
-    FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));
+    FontInstaller::buildFontPath(family.name, file.name, destPath, sizeof(destPath));
 
-    std::string url = baseUrl_ + file.name;
+    // Stack buffer, not std::string concatenation: this runs immediately before
+    // the TLS handshake, where a transient heap allocation is exactly what the
+    // contiguous-block budget cannot afford. baseUrl_ is 67 bytes, names reach 30.
+    char url[192];
+    snprintf(url, sizeof(url), "%s%s", baseUrl_, file.name);
 
     // Fire the render task only on whole-percent change. HttpDownloader reads in
     // 1KB chunks, so a per-chunk update would wake the render task ~400 times for
@@ -257,8 +275,8 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
         nullptr, "", "", HttpDownloader::BufferProfile::LARGE);
 
     if (result != HttpDownloader::OK) {
-      LOG_ERR("FONT", "Download failed: %s err=%d http=%d heap=%d blk=%d got=%zu", file.name.c_str(),
-              static_cast<int>(result), HttpDownloader::lastHttpCode, static_cast<int>(ESP.getFreeHeap()),
+      LOG_ERR("FONT", "Download failed: %s err=%d http=%d heap=%d blk=%d got=%zu", file.name, static_cast<int>(result),
+              HttpDownloader::lastHttpCode, static_cast<int>(ESP.getFreeHeap()),
               static_cast<int>(ESP.getMaxAllocHeap()), fileProgress_);
       char buf[80];
       // Same diagnostics as the manifest fetch: err is DownloadError, http is
@@ -270,7 +288,7 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
                static_cast<int>(ESP.getMaxAllocHeap() / 1024), static_cast<int>(fileProgress_ / 1024));
       RenderLock lock(*this);
       state_ = ERROR;
-      errorMessage_ = "Download failed: " + file.name;
+      errorMessage_ = std::string("Download failed: ") + file.name;
       errorDetail_ = buf;
       return;
     }
@@ -280,7 +298,7 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
       Storage.remove(destPath);
       RenderLock lock(*this);
       state_ = ERROR;
-      errorMessage_ = "Invalid font file: " + file.name;
+      errorMessage_ = std::string("Invalid font file: ") + file.name;
       return;
     }
   }
@@ -427,7 +445,7 @@ void FontDownloadActivity::render(RenderLock&&) {
 
       size_t totalFiles = 0;
       for (const auto& f : families_) {
-        if (!f.installed) totalFiles += f.files.size();
+        if (!f.installed) totalFiles += f.fileCount;
       }
       renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y,
                         (std::string(tr(STR_FILES_LABEL)) + std::to_string(totalFiles)).c_str());
@@ -441,7 +459,7 @@ void FontDownloadActivity::render(RenderLock&&) {
       renderer.drawCenteredText(UI_10_FONT_ID, y, confirmText.c_str());
       y += lineHeight + metrics.verticalSpacing;
       renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y,
-                        (std::string(tr(STR_FILES_LABEL)) + std::to_string(family.files.size())).c_str());
+                        (std::string(tr(STR_FILES_LABEL)) + std::to_string(family.fileCount)).c_str());
       y += lineHeight + metrics.verticalSpacing;
       renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y,
                         (std::string(tr(STR_SIZE_LABEL)) + formatSize(family.totalSize)).c_str());

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -81,7 +81,12 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   static constexpr const char* MANIFEST_TMP = "/fonts_manifest.tmp";
 
   const size_t heapBefore = ESP.getFreeHeap();
-  auto result = HttpDownloader::downloadToFile(FONT_MANIFEST_URL, MANIFEST_TMP, nullptr);
+  // LARGE buffers: the manifest lives on a GitHub release, which redirects to a
+  // signed release-assets.githubusercontent.com URL ~860 bytes long. That request
+  // line does not fit the default 512-byte TX buffer, so the reopen after the 302
+  // fails with ESP_FAIL before any byte arrives — see HttpDownloader::BufferProfile.
+  auto result = HttpDownloader::downloadToFile(FONT_MANIFEST_URL, MANIFEST_TMP, nullptr, nullptr, "", "",
+                                               HttpDownloader::BufferProfile::LARGE);
   if (result != HttpDownloader::OK) {
     LOG_ERR("FONT", "Manifest fetch failed (err=%d, http=%d, heap=%zu)", result, HttpDownloader::lastHttpCode,
             heapBefore);
@@ -229,11 +234,16 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
 
     std::string url = baseUrl_ + file.name;
 
-    auto result = HttpDownloader::downloadToFile(url, destPath, [this](size_t downloaded, size_t total) {
-      fileProgress_ = downloaded;
-      fileTotal_ = total;
-      requestUpdate(true);
-    });
+    // LARGE buffers for the same reason as the manifest fetch: the signed
+    // redirect target runs ~900 bytes for the longest font file name.
+    auto result = HttpDownloader::downloadToFile(
+        url, destPath,
+        [this](size_t downloaded, size_t total) {
+          fileProgress_ = downloaded;
+          fileTotal_ = total;
+          requestUpdate(true);
+        },
+        nullptr, "", "", HttpDownloader::BufferProfile::LARGE);
 
     if (result != HttpDownloader::OK) {
       LOG_ERR("FONT", "Download failed: %s (%d)", file.name.c_str(), result);

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -70,6 +70,9 @@ class FontDownloadActivity : public Activity {
   size_t fileTotal_ = 0;
   int downloadingFamilyIndex_ = 0;
   std::string errorMessage_;
+  // Second error line: err/http/heap diagnostics. Kept separate from
+  // errorMessage_ so the failing file name stays readable on its own line.
+  std::string errorDetail_;
 
   void onWifiSelectionComplete(bool success);
   bool fetchAndParseManifest();

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -39,17 +39,26 @@ class FontDownloadActivity : public Activity {
     ERROR,
   };
 
+  // Fixed-size records rather than std::string members. The manifest holds 25
+  // families and 108 files; as std::string those cost 200+ separate heap
+  // allocations scattered across the arena, and the per-family files vector
+  // grew without reserve() on top of that. The resulting fragmentation is what
+  // starved the ~45-55KB contiguous block a TLS handshake needs — the font
+  // download failed with ESP_ERR_HTTP_CONNECT while 70KB was still free but the
+  // largest block was only 37KB. Capacities are the measured manifest maxima
+  // (file name 30, family name 20, description 72) plus headroom; anything
+  // longer is truncated, which only shortens a label.
   struct ManifestFile {
-    std::string name;
-    size_t size = 0;
+    char name[40] = {0};
+    uint32_t size = 0;
   };
 
   struct ManifestFamily {
-    std::string name;
-    std::string description;
-    std::vector<std::string> styles;
-    std::vector<ManifestFile> files;
-    size_t totalSize = 0;
+    char name[32] = {0};
+    char description[80] = {0};
+    uint16_t fileStart = 0;  // index of this family's first entry in allFiles_
+    uint8_t fileCount = 0;
+    uint32_t totalSize = 0;
     bool installed = false;
     bool hasUpdate = false;
   };
@@ -58,9 +67,11 @@ class FontDownloadActivity : public Activity {
   FontInstaller fontInstaller_;
   ButtonNavigator buttonNavigator_;
 
-  // Manifest data
-  std::string baseUrl_;
+  // Manifest data. Two heap blocks total: one for families_, one for the flat
+  // file list every family indexes into.
+  char baseUrl_[96] = {0};
   std::vector<ManifestFamily> families_;
+  std::vector<ManifestFile> allFiles_;
   int selectedIndex_ = 0;
 
   // Download progress

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -287,7 +287,8 @@ bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData
 
 HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url, const std::string& destPath,
                                                              ProgressCallback progress, bool* cancelFlag,
-                                                             const std::string& username, const std::string& password) {
+                                                             const std::string& username, const std::string& password,
+                                                             BufferProfile buffers) {
   LOG_DBG("HTTP", "Downloading: %s -> %s", url.c_str(), destPath.c_str());
 
   if (Storage.exists(destPath.c_str())) {
@@ -304,7 +305,7 @@ HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& 
   sink.cancelFlag = cancelFlag;
   sink.write = [&file](const uint8_t* data, size_t len) { return file.write(data, len) == len; };
 
-  const DownloadError result = runGetSecure(url, username, password, sink, BufferProfile::COMPACT);
+  const DownloadError result = runGetSecure(url, username, password, sink, buffers);
   // Close before any remove() on the same path; DESTRUCTOR_CLOSES_FILE would
   // otherwise close only after the remove.
   file.close();

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -28,10 +28,12 @@ class HttpDownloader {
    * front and held for the whole connection.
    *
    * COMPACT is the default. LARGE exists only for GitHub's release CDN: the
-   * redirect target (objects.githubusercontent.com) is a signed URL whose
-   * path+query runs 700-900 bytes, so the redirected GET's request line
+   * redirect target (release-assets.githubusercontent.com) is a signed URL
+   * whose path+query runs 700-900 bytes, so the redirected GET's request line
    * overflows a 512-byte TX buffer and the reopen fails before any byte
-   * arrives.
+   * arrives. esp_http_client reports that as ESP_FAIL ("Out of buffer" in
+   * esp_http_client_request_send), which surfaces as http=1 in the activities'
+   * diagnostics — not as a connect error.
    *
    * The distinction matters because a TLS handshake needs ~45-55KB of
    * contiguous heap on this device (MBEDTLS_SSL_IN/OUT_CONTENT_LEN are 16KB
@@ -71,5 +73,6 @@ class HttpDownloader {
    */
   static DownloadError downloadToFile(const std::string& url, const std::string& destPath,
                                       ProgressCallback progress = nullptr, bool* cancelFlag = nullptr,
-                                      const std::string& username = "", const std::string& password = "");
+                                      const std::string& username = "", const std::string& password = "",
+                                      BufferProfile buffers = BufferProfile::COMPACT);
 };

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -175,9 +175,9 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   bool flashOk = true;
   esp_err_t writeErr = ESP_OK;
   // LARGE buffers: otaUrl points at the release asset, which redirects to a
-  // signed objects.githubusercontent.com URL whose request line does not fit
-  // the default 512-byte TX buffer. This is the only caller that needs them —
-  // see HttpDownloader::BufferProfile.
+  // signed release-assets.githubusercontent.com URL whose request line does not
+  // fit the default 512-byte TX buffer. FontDownloadActivity needs them for the
+  // same reason — see HttpDownloader::BufferProfile.
   const bool fetchOk = HttpDownloader::fetchUrl(
       otaUrl,
       [&](const uint8_t* data, size_t len) {


### PR DESCRIPTION
## 概要

フォントダウンロード機能が使用不能だった。原因は独立した 2 つの問題で、いずれも実機で検証・修正済み。

## 問題 1: 一覧取得が TX バッファ不足で失敗 (`err=1 http=1`)

GitHub リリースアセットは署名付きの `release-assets.githubusercontent.com` URL へ 302 リダイレクトされる。実測した path+query は以下の通り。

| 対象 | path+query |
|---|---|
| `fonts.json` | 859 バイト |
| 最長フォント `AtkinsonHyperlegible_12.cpfont` | 899 バイト |

ESP-IDF の `esp_http_client_request_send()` は `snprintf(buf, buffer_size_tx, "%s %s", method, path)` が溢れると `"Out of buffer"` で `ESP_FAIL` を返す。これが画面表示の `http=1` (`-(-1)`) の正体。

`downloadToFile()` は `BufferProfile` を受け取る引数自体がなく TX 512 バイト固定だった。同じ CDN を使う OTA は既に `BufferProfile::LARGE` を指定済みで、フォント側だけ対策が漏れていた。

- `downloadToFile()` に `BufferProfile` 引数を追加 (既定 `COMPACT` のため他の呼び出し元は挙動不変)
- マニフェスト取得とフォント本体取得を `LARGE` に

## 問題 2: 本体ダウンロードがヒープ断片化で失敗 (`http=-28674 got=0KB`)

`-28674` = `ESP_ERR_HTTP_CONNECT`、`got=0KB` は 1 バイトも受信していないことを示す。空きヒープ 70KB に対し最大連続ブロックが 37KB しかなく、TLS ハンドシェイクに必要な約 45〜55KB を確保できていなかった。

マニフェスト (25 ファミリー / 108 ファイル) を `std::string` メンバで保持していたため、200 回以上の細かいヒープ確保がアリーナ全体に散らばっていた。さらに `ManifestFamily::files` は `reserve()` なしの `push_back` で成長し、再確保のたびに穴を空けていた。

| 項目 | 変更前 | 変更後 |
|---|---|---|
| ヒープ確保回数 | 200 回以上 (分散) | 2 回 |
| `files` vector | `reserve()` なし | 正確に `reserve()` 済み |
| `styles` | 全ファミリー空なのに毎回構築 | 削除 (参照箇所なし) |

- `ManifestFile` / `ManifestFamily` を固定長 `char` 配列に変更 (実測最大値 + 余裕、超過分は切り詰め)
- `files` をフラットな `allFiles_` に統合し確保を 2 ブロックに集約
- ダウンロード URL 構築を `std::string` 連結から `snprintf` に変更 (ハンドシェイク直前の一時確保を回避)

## 副次的な改善

- **診断表示**: エラー画面に 2 行目を追加し `err/http/heap/blk/got` を表示。従来はファイル名のみで `DownloadError` も `esp_err` も分からず切り分け不能だった
- **プログレス通知の抑制**: 1% 刻みに変更。`HttpDownloader` は 1KB チャンクで読むため、423KB のフォント 1 本でレンダータスクを約 400 回起こしていた。`OtaUpdater::installUpdate` が同じ理由で 1% 刻みにしている

## 検証

- [x] `pio run` 成功 (RAM 31.3% / Flash 92.1%)
- [x] `bin/clang-format-fix` 差分なし (clang-format 21.1.5)
- [x] `pio check --fail-on-defect low/medium/high` defect なし
- [x] **実機でフォント一覧の表示とインストールが成功することを確認**

🤖 Generated with [Claude Code](https://claude.com/claude-code)