### PR TITLE
fix: 縦書きの小書き仮名の位置と行頭禁則を修正

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 // Version 31: ruby text data added to TextBlock serialization.
-constexpr uint8_t SECTION_FILE_VERSION = 31;
+constexpr uint8_t SECTION_FILE_VERSION = 32;
 // Minimum free heap required before attempting to build section pages.
 // Section building involves heavy allocations (Page, TextBlock, PageLine, etc.)
 // and on ESP32 without C++ exceptions, allocation failure calls abort().

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1908,7 +1908,18 @@ void GfxRenderer::drawTextVertical(const int fontId, const int x, const int y, c
         charBuf[1] = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
         charBuf[2] = static_cast<char>(0x80 | (cp & 0x3F));
       }
-      drawText(effectiveFontId, x, yPos, charBuf, black, style);
+      // Small kana are designed for horizontal layout, where they sit low in
+      // the em box. Vertical layout wants them toward the upper right, so
+      // shift the drawn glyph by the measured 'vert' displacement. Only the
+      // draw position moves - the cell advance is unchanged, so column layout,
+      // kinsoku and cached section geometry are unaffected.
+      int drawX = x;
+      int drawY = yPos;
+      if (VerticalTextUtils::isSmallKana(cp)) {
+        drawX += (advance * VerticalTextUtils::SMALL_KANA_DX_PERCENT + 50) / 100;
+        drawY -= (advance * VerticalTextUtils::SMALL_KANA_DY_PERCENT + 50) / 100;
+      }
+      drawText(effectiveFontId, drawX, drawY, charBuf, black, style);
       yPos += verticalAdvance;
     }
   }

--- a/lib/GfxRenderer/VerticalTextUtils.h
+++ b/lib/GfxRenderer/VerticalTextUtils.h
@@ -166,12 +166,11 @@ inline bool isKinsokuHead(uint32_t cp) {
   if (cp == 0xFF01 || cp == 0xFF1F) return true;                                  // ！？
   if (cp == 0xFF1A || cp == 0xFF1B) return true;                                  // ：；
   if (cp == 0x3009 || cp == 0x300B) return true;                                  // 〉》
-  // Small kana (行頭禁止)
-  if (cp == 0x3041 || cp == 0x3043 || cp == 0x3045 || cp == 0x3047 || cp == 0x3049) return true;  // ぁぃぅぇぉ
-  if (cp == 0x3063 || cp == 0x3083 || cp == 0x3085 || cp == 0x3087) return true;                  // っゃゅょ
-  if (cp == 0x30A1 || cp == 0x30A3 || cp == 0x30A5 || cp == 0x30A7 || cp == 0x30A9) return true;  // ァィゥェォ
-  if (cp == 0x30C3 || cp == 0x30E3 || cp == 0x30E5 || cp == 0x30E7) return true;                  // ッャュョ
-  if (cp == 0x30FC) return true;                                                                  // ー
+  // Small kana (行頭禁止). Shares isSmallKana() so the two lists cannot drift:
+  // the open-coded version here used to omit ゎ ヮ ゕ ゖ ヵ ヶ and the Ainu
+  // small katakana, which JIS X 4051 treats the same as っ ゃ ゅ ょ.
+  if (isSmallKana(cp)) return true;
+  if (cp == 0x30FC) return true;  // ー
   return false;
 }
 

--- a/lib/GfxRenderer/VerticalTextUtils.h
+++ b/lib/GfxRenderer/VerticalTextUtils.h
@@ -83,6 +83,105 @@ inline bool isUprightInVertical(uint32_t cp) {
   return false;
 }
 
+// Vertical repositioning for small kana (小書き仮名), as a percentage of the
+// full-width advance (em). In horizontal layout a small kana glyph is drawn
+// low in the em box and roughly centred horizontally; vertical layout places
+// it toward the upper right (JLREQ 3.1.4 / JIS X 4051).
+//
+// The magnitudes below are measured, not guessed. For each of the 24 small
+// kana the OpenType 'vert' substitute was compared against its base glyph in
+// seven typefaces, and the displacement taken as the shift of the ink
+// bounding box *centre*:
+//
+//   NotoSansCJKjp Regular  +0.112 em right  +0.106 em up
+//   NotoSansCJKjp Bold     +0.104           +0.106
+//   Hiragino Kaku Gothic W3 +0.112          +0.108
+//   Hiragino Kaku Gothic W6 +0.103          +0.098
+//   Hiragino Mincho ProN   +0.114           +0.099
+//   Hiragino Maru Gothic W4 +0.102          +0.094
+//   Hiragino Sans GB       +0.111           +0.108
+//   ------------------------------------------------
+//   mean                   +0.1083          +0.1028
+//
+// NotoSansCJKjp matters most here: it is the source of the bundled .cpfont
+// files (lib/EpdFont/scripts/downloaded_fonts/).
+//
+// Each row is a mean over the 24 characters (166 glyph pairs in total). The
+// means are tight across typefaces, but individual characters are not: the
+// per-character standard deviation is 0.013 em horizontally and 0.020 em
+// vertically (full spread 0.073..0.158 and 0.060..0.166). A single constant
+// is a deliberate approximation of that spread - a per-character table would
+// cost flash and complexity for a correction whose residual error is well
+// under one pixel at the em sizes this firmware renders (25-38 px).
+//
+// Centre rather than corner is the right reference because we translate the
+// unmodified horizontal glyph. Hiragino's vert forms are pure translations so
+// the two agree, but Noto redraws them slightly smaller, and aligning corners
+// would then overshoot to the upper right by the size difference.
+//
+// Note the offsets are deliberately derived from the advance alone and not
+// from the glyph ink box: EpdGlyph width/height/left/top are post-rasterisation
+// bitmap extents, so at a ~30 px em a one-pixel cropping difference is already
+// 0.03 em of error. The advance carries no such error.
+static constexpr int SMALL_KANA_DX_PERCENT = 11;  // rightward, % of em
+static constexpr int SMALL_KANA_DY_PERCENT = 10;  // upward, % of em
+
+// Is this codepoint a small kana needing the offset above in vertical text?
+inline constexpr bool isSmallKana(uint32_t cp) {
+  if (cp >= 0x3041 && cp <= 0x3096) {  // Hiragana
+    switch (cp) {
+      case 0x3041:  // ぁ
+      case 0x3043:  // ぃ
+      case 0x3045:  // ぅ
+      case 0x3047:  // ぇ
+      case 0x3049:  // ぉ
+      case 0x3063:  // っ
+      case 0x3083:  // ゃ
+      case 0x3085:  // ゅ
+      case 0x3087:  // ょ
+      case 0x308E:  // ゎ
+      case 0x3095:  // ゕ
+      case 0x3096:  // ゖ
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (cp >= 0x30A1 && cp <= 0x30F6) {  // Katakana
+    switch (cp) {
+      case 0x30A1:  // ァ
+      case 0x30A3:  // ィ
+      case 0x30A5:  // ゥ
+      case 0x30A7:  // ェ
+      case 0x30A9:  // ォ
+      case 0x30C3:  // ッ
+      case 0x30E3:  // ャ
+      case 0x30E5:  // ュ
+      case 0x30E7:  // ョ
+      case 0x30EE:  // ヮ
+      case 0x30F5:  // ヵ
+      case 0x30F6:  // ヶ
+        return true;
+      default:
+        return false;
+    }
+  }
+  // Katakana Phonetic Extensions - small katakana for Ainu (ㇰㇱㇲ...).
+  // All 16 are small forms. Their measured displacement (+0.102 em right,
+  // +0.091 em up) sits within the spread of the main set, so they share the
+  // same constants.
+  if (cp >= 0x31F0 && cp <= 0x31FF) return true;
+  // Halfwidth small katakana (U+FF67..FF6F) are excluded on purpose, even
+  // though isUprightInVertical() above sends them down the same upright path.
+  // Two reasons: none of the seven typefaces measured carries a 'vert'
+  // substitute for them, so there is nothing to derive an offset from; and
+  // the model does not apply anyway, since a halfwidth kana fills its narrow
+  // cell rather than sitting small and low inside a full-width em box.
+  // (Four of the Hiragino faces do define halfwidth forms under 'vrt2', but
+  // fontconvert_sdcard.py reads only 'vert', so they never reach this code.)
+  return false;
+}
+
 // Should this codepoint use the OpenType 'vert' substitute glyph?
 // Returns true only for punctuation, brackets, and long marks that need
 // a different glyph shape in vertical text. Kana and ideographs are excluded

--- a/lib/GfxRenderer/VerticalTextUtils.h
+++ b/lib/GfxRenderer/VerticalTextUtils.h
@@ -11,61 +11,6 @@ enum class VerticalBehavior : uint8_t {
   TateChuYoko,  // 1-2 digit numbers - horizontal-in-vertical
 };
 
-// Punctuation offset for vertical text (ratio of character size, in 1/8 units)
-struct PunctuationOffset {
-  uint32_t codepoint;
-  int8_t dxEighths;  // horizontal offset in 1/8 of charWidth
-  int8_t dyEighths;  // vertical offset in 1/8 of charHeight
-  bool rotate;       // true = rotate 90 CW (e.g. long vowel mark)
-};
-
-// CJK punctuation and brackets that need 90 CW rotation in vertical text.
-// Horizontal font glyphs are designed for horizontal layout; rotating them
-// naturally transforms their position to the correct vertical placement
-// (e.g. 。at bottom-left becomes upper-right after rotation).
-// dx/dyEighths are post-rotation fine-tuning offsets (usually 0).
-static constexpr PunctuationOffset VERTICAL_PUNCTUATION[] = {
-    // Punctuation - rotate to reposition from horizontal to vertical placement
-    {0x3001, 0, 0, true},  // 、 ideographic comma
-    {0x3002, 0, 0, true},  // 。 ideographic period
-    {0xFF0C, 0, 0, true},  // ， fullwidth comma
-    {0xFF0E, 0, 0, true},  // ． fullwidth period
-    {0xFF01, 0, 0, true},  // ！ fullwidth exclamation
-    {0xFF1F, 0, 0, true},  // ？ fullwidth question mark
-    {0xFF1A, 0, 0, true},  // ： fullwidth colon
-    {0xFF1B, 0, 0, true},  // ； fullwidth semicolon
-    // Brackets - rotate so opening/closing direction matches vertical flow
-    {0x300C, 0, 0, true},  // 「 left corner bracket
-    {0x300D, 0, 0, true},  // 」 right corner bracket
-    {0x300E, 0, 0, true},  // 『 left white corner bracket
-    {0x300F, 0, 0, true},  // 』 right white corner bracket
-    {0x3010, 0, 0, true},  // 【 left black lenticular bracket
-    {0x3011, 0, 0, true},  // 】 right black lenticular bracket
-    {0xFF08, 0, 0, true},  // （ fullwidth left paren
-    {0xFF09, 0, 0, true},  // ） fullwidth right paren
-    {0x3008, 0, 0, true},  // 〈 left angle bracket
-    {0x3009, 0, 0, true},  // 〉 right angle bracket
-    {0x300A, 0, 0, true},  // 《 left double angle bracket
-    {0x300B, 0, 0, true},  // 》 right double angle bracket
-    {0x3014, 0, 0, true},  // 〔 left tortoise shell bracket
-    {0x3015, 0, 0, true},  // 〕 right tortoise shell bracket
-    // Long marks - rotate to vertical orientation
-    {0x30FC, 0, 0, true},  // ー katakana long vowel mark
-    {0x2014, 0, 0, true},  // — em dash
-    {0x2015, 0, 0, true},  // ― horizontal bar
-    {0x2026, 0, 0, true},  // … ellipsis
-    {0xFF5E, 0, 0, true},  // ～ fullwidth tilde
-};
-static constexpr int VERTICAL_PUNCTUATION_COUNT = sizeof(VERTICAL_PUNCTUATION) / sizeof(VERTICAL_PUNCTUATION[0]);
-
-// Look up punctuation offset. Returns nullptr if no special handling needed.
-inline const PunctuationOffset* getVerticalPunctuationOffset(uint32_t cp) {
-  for (int i = 0; i < VERTICAL_PUNCTUATION_COUNT; i++) {
-    if (VERTICAL_PUNCTUATION[i].codepoint == cp) return &VERTICAL_PUNCTUATION[i];
-  }
-  return nullptr;
-}
-
 // Determine if a codepoint should be drawn upright in vertical text.
 // CJK ideographs, kana, CJK symbols, fullwidth forms, etc.
 inline bool isUprightInVertical(uint32_t cp) {


### PR DESCRIPTION
縦書きの小書き仮名まわりの修正 3 件です。

## 1. 小書き仮名が下に沈んで見える（描画位置の補正）

横組み用グリフは仮想ボディ内で下寄りに置かれているため、縦組みでそのまま描画すると字面が下がります。正しい縦組みでは右上寄りに置かれます（JLREQ 3.1.4 / JIS X 4051）。

`drawTextVertical()` のフォールバック経路で、小書き仮名のときだけ描画位置を `advance` 比で右上にずらします。実質 11 行の追加です。

```cpp
if (VerticalTextUtils::isSmallKana(cp)) {
  drawX += (advance * VerticalTextUtils::SMALL_KANA_DX_PERCENT + 50) / 100;
  drawY -= (advance * VerticalTextUtils::SMALL_KANA_DY_PERCENT + 50) / 100;
}
```

セルの `advance` は変えないので、行送り・カラム分割・禁則・ルビ位置に影響しません。フォントの再生成・再配布も不要で、組み込みフォント・SD カードフォントの双方に効きます。ヒープ確保はなく、定数・判定関数は Flash に置かれます。

### オフセット量の根拠

推測ではなく実測値です。日本語書体 7 種について、小書き仮名 24 字の OpenType `vert` 代替グリフとベースグリフのインクバウンディングボックス**中心**の変位を、計 166 グリフ対にわたって測定しました。

| 書体 | 右 | 上 |
|---|---|---|
| NotoSansCJKjp Regular | +0.112 em | +0.106 em |
| NotoSansCJKjp Bold | +0.104 | +0.106 |
| ヒラギノ角ゴ W3 | +0.112 | +0.108 |
| ヒラギノ角ゴ W6 | +0.103 | +0.098 |
| ヒラギノ明朝 ProN | +0.114 | +0.099 |
| ヒラギノ丸ゴ W4 | +0.102 | +0.094 |
| ヒラギノ Sans GB | +0.111 | +0.108 |
| **平均** | **+0.1083** | **+0.1028** |

採用値は右 11% / 上 10%。NotoSansCJKjp は `.cpfont` の変換元なので最も重視しています。

- **中心基準を使う理由**: 本実装は横組み用グリフをそのまま平行移動させます。ヒラギノの `vert` グリフは純粋な平行移動なので隅基準でも同値ですが、Noto はアウトラインを約 6% 小さく描き直しているため、隅基準では右上に行き過ぎます
- **グリフのインクボックスから算出しない理由**: `EpdGlyph` の `width/height/left/top` はラスタライズ後のビットマップ範囲で、em ≈ 30px では 1px の切り出し差が 0.03 em の誤差になります。`advance` にはこの誤差がありません
- **字種ごとのばらつき**は無視できません（標準偏差は右 0.013 em / 上 0.020 em）。単一定数はそれを承知の上での近似で、em 25〜38px では残差が 1px を下回るため、字種別テーブルは Flash と複雑さに見合わないと判断しました
- **半角小書きカタカナ (U+FF67-FF6F) は対象外**です。`isUprightInVertical` が 0xFF00-0xFFEF を含むため正立経路には到達しますが、測定した 7 書体のいずれも `vert` に代替を持たず、半角カナは狭いセルを埋めるデザインなので補正モデル自体が当てはまりません

## 2. 未参照の約物オフセットテーブルを削除

`PunctuationOffset` 構造体、`VERTICAL_PUNCTUATION` テーブル、`getVerticalPunctuationOffset()` を削除します。OpenType `vert` 代替グリフ方式の導入前の残骸で、`lib/` `src/` 全体を grep して参照が 1 件もないことを確認済みです。挙動は変わらず、Flash が 114 バイト減ります。

## 3. 小書き仮名の行頭禁則の漏れを解消

`isKinsokuHead()` の列挙から `ゎ` `ヮ` `ゕ` `ゖ` `ヵ` `ヶ` とアイヌ語表記用の小書きカタカナ (U+31F0-31FF) が漏れていました。JIS X 4051 はこれらを `っ` `ゃ` `ゅ` `ょ` と同じ行頭禁則の対象として扱います。「三ヶ月」の `ヶ` のように実際に出現する字も含まれています。

列挙を直接書く代わりに `isSmallKana()` を呼ぶことで、2 つのリストが今後ずれないようにしました。

### ⚠️ キャッシュ再生成が必要です

`isKinsokuHead()` は `ParsedText::layoutVerticalColumns()` のカラム分割で使われ、結果が `section.bin` に焼かれます。禁則が変わるとレイアウト結果も変わるため、**`SECTION_FILE_VERSION` を 31 → 32 にインクリメント**しました。バイナリ構造自体は不変です。

これを怠ると既にキャッシュ済みの本に修正が反映されません。再生成は本を開いたときにセクション単位で遅延実行されるため、フォントサイズ変更時と同等の一度きりのコストで済みます。

なお **1.（描画位置の補正）は単体ではキャッシュ再生成を必要としません**。再生成が要るのは 3. の禁則修正だけです。

## 検証

- `pio run` SUCCESS（RAM 31.3% で変更前と同一、Flash 6,277,799 バイトで 114 バイト減）
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` → No defects found
- `bin/clang-format-fix` 実行後の差分なし
- **実機（Xteink X3）で 1. を確認済み**。縦書き検証用 EPUB（小書き仮名 24 字の親字との対比、実際の語、ルビの拗音、約物の退行確認、半角小書き）で表示を確認

修正前の状態はスクリーンショットからピクセル測定して定量化しました。小書き仮名が本来より 5.78px（em 30px に対し 0.19 em 相当）下に沈んでおり、水平方向のオフセットは 0px でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)