### PR TITLE
perf: 章インデックスのadvanceテーブル再構築を解消して6倍高速化

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -934,6 +934,20 @@ uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
   return entry ? entry->advanceX : 0;
 }
 
+bool SdCardFont::tryGetAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const {
+  if (style >= MAX_STYLES || (!advanceTable_[style] && !advanceSpill_[style])) {
+    if (style != 0 && (advanceTable_[0] || advanceSpill_[0])) {
+      style = 0;  // fallback to Regular
+    } else {
+      return false;
+    }
+  }
+  const AdvanceEntry* entry = findAdvanceEntry(style, codepoint);
+  if (!entry || !entry->hasGlyph) return false;
+  advanceOut = entry->advanceX;
+  return true;
+}
+
 // 累積テーブルを needed エントリぶん収容できるまで伸長する。
 // AdvanceEntry は POD なので realloc が使える（その場拡張が効けばコピーも起きない）。
 bool SdCardFont::ensureAdvanceCapacity(const uint8_t styleIdx, const uint32_t needed) {
@@ -979,11 +993,18 @@ int SdCardFont::buildAdvanceTable(const char* utf8Text, uint8_t styleMask) {
 int SdCardFont::buildAdvanceTableForStyle(const uint8_t styleIdx, const char* utf8Text) {
   const auto& s = styles_[styleIdx];
 
+  // グリフを持たない字は renderChar() が '?' を描くので、レイアウトもその幅に
+  // 合わせる必要がある（GfxRenderer::getTextAdvanceX を参照）。参照できるよう
+  // このスタイルの最初の構築時に '?' を必ずテーブルへ載せておく。
+  const bool seedFallbackGlyph = (advanceTableSize_[styleIdx] == 0);
+  const char* const segments[2] = {utf8Text, seedFallbackGlyph ? "?" : nullptr};
+
   // Pass 1: 未取得のコードポイント数を数える（重複を含む上限値）。
   // ゼロなら確保も I/O も一切せずに戻る。
   uint32_t missUpperBound = 0;
-  {
-    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
+  for (const char* segment : segments) {
+    if (!segment) continue;
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(segment);
     while (*p) {
       const uint32_t cp = utf8NextCodepoint(&p);
       if (cp == 0) break;
@@ -1008,8 +1029,9 @@ int SdCardFont::buildAdvanceTableForStyle(const uint8_t styleIdx, const char* ut
   // Pass 2: 未取得のコードポイントを重複除去して集める。
   // 除去対象は未取得ぶんだけなので、O(n²) でも実際の件数は小さい。
   uint32_t missCount = 0;
-  {
-    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
+  for (const char* segment : segments) {
+    if (!segment) continue;
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(segment);
     while (*p && missCount < missUpperBound) {
       const uint32_t cp = utf8NextCodepoint(&p);
       if (cp == 0) break;

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -5,6 +5,7 @@
 #include <Utf8.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 
@@ -874,218 +875,250 @@ bool SdCardFont::loadVertData(uint8_t style) {
 // --- Advance table ---
 
 void SdCardFont::clearAdvanceTables() {
+  clearAdvanceSpill();
   for (uint8_t i = 0; i < MAX_STYLES; i++) {
-    delete[] advanceTable_[i];
+    free(advanceTable_[i]);
     advanceTable_[i] = nullptr;
     advanceTableSize_[i] = 0;
+    advanceTableCap_[i] = 0;
+  }
+}
+
+void SdCardFont::clearAdvanceSpill() {
+  for (uint8_t i = 0; i < MAX_STYLES; i++) {
+    free(advanceSpill_[i]);
+    advanceSpill_[i] = nullptr;
+    advanceSpillSize_[i] = 0;
   }
 }
 
 bool SdCardFont::hasAdvanceTable() const {
   for (uint8_t i = 0; i < MAX_STYLES; i++) {
-    if (advanceTable_[i]) return true;
+    if (advanceTable_[i] || advanceSpill_[i]) return true;
   }
   return false;
+}
+
+// 累積テーブル → ブロックローカルの退避テーブルの順に引く。どちらもコードポイント昇順。
+const SdCardFont::AdvanceEntry* SdCardFont::findAdvanceEntry(const uint8_t styleIdx, const uint32_t codepoint) const {
+  if (styleIdx >= MAX_STYLES) return nullptr;
+  for (int pass = 0; pass < 2; pass++) {
+    const AdvanceEntry* table = (pass == 0) ? advanceTable_[styleIdx] : advanceSpill_[styleIdx];
+    const uint32_t size = (pass == 0) ? advanceTableSize_[styleIdx] : advanceSpillSize_[styleIdx];
+    if (!table || size == 0) continue;
+    uint32_t lo = 0, hi = size;
+    while (lo < hi) {
+      const uint32_t mid = lo + (hi - lo) / 2;
+      if (table[mid].codepoint < codepoint) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    if (lo < size && table[lo].codepoint == codepoint) return &table[lo];
+  }
+  return nullptr;
 }
 
 uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
   // Fall back to Regular (style 0) if requested style has no advance table
   // (e.g., Bold requested but font only has Regular)
-  if (style >= MAX_STYLES || !advanceTable_[style]) {
-    if (style != 0 && advanceTable_[0]) {
+  if (style >= MAX_STYLES || (!advanceTable_[style] && !advanceSpill_[style])) {
+    if (style != 0 && (advanceTable_[0] || advanceSpill_[0])) {
       style = 0;  // fallback to Regular
     } else {
       return 0;
     }
   }
-  const AdvanceEntry* table = advanceTable_[style];
-  const uint32_t size = advanceTableSize_[style];
-  // Binary search sorted by codepoint
-  uint32_t lo = 0, hi = size;
-  while (lo < hi) {
-    uint32_t mid = lo + (hi - lo) / 2;
-    if (table[mid].codepoint < codepoint) {
-      lo = mid + 1;
-    } else {
-      hi = mid;
-    }
+  const AdvanceEntry* entry = findAdvanceEntry(style, codepoint);
+  return entry ? entry->advanceX : 0;
+}
+
+// 累積テーブルを needed エントリぶん収容できるまで伸長する。
+// AdvanceEntry は POD なので realloc が使える（その場拡張が効けばコピーも起きない）。
+bool SdCardFont::ensureAdvanceCapacity(const uint8_t styleIdx, const uint32_t needed) {
+  if (needed <= advanceTableCap_[styleIdx]) return true;
+  if (needed > ADVANCE_TABLE_MAX_CAP) return false;
+
+  uint32_t cap = advanceTableCap_[styleIdx] ? advanceTableCap_[styleIdx] : ADVANCE_TABLE_INITIAL_CAP;
+  while (cap < needed) cap *= 2;
+  if (cap > ADVANCE_TABLE_MAX_CAP) cap = ADVANCE_TABLE_MAX_CAP;
+
+  auto* grown = static_cast<AdvanceEntry*>(realloc(advanceTable_[styleIdx], cap * sizeof(AdvanceEntry)));
+  if (!grown) {
+    LOG_ERR("SDCF", "advance table grow failed (style %u, %u entries)", styleIdx, cap);
+    return false;
   }
-  if (lo < size && table[lo].codepoint == codepoint) {
-    return table[lo].advanceX;
-  }
-  return 0;
+  advanceTable_[styleIdx] = grown;
+  advanceTableCap_[styleIdx] = cap;
+  return true;
 }
 
 int SdCardFont::buildAdvanceTable(const char* utf8Text, uint8_t styleMask) {
   if (!loaded_) return -1;
 
-  clearAdvanceTables();
+  // 退避テーブルだけがブロックローカル。累積テーブル（advanceTable_）は破棄しない。
+  clearAdvanceSpill();
 
-  unsigned long startMs = millis();
+  const unsigned long startMs = millis();
 
-  // Step 1: Extract unique codepoints (no limit).
-  // First pass: count total codepoints to size the dedup buffer.
-  uint32_t totalChars = 0;
-  {
-    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
-    while (*p) {
-      utf8NextCodepoint(&p);
-      totalChars++;
-    }
-  }
-  if (totalChars == 0) return 0;
-
-  // Allocate buffer for unique codepoints.
-  // Cap at MAX_ADVANCE_CODEPOINTS to prevent OOM on large CJK sections.
-  // Codepoints beyond the cap are still renderable via onGlyphMiss(), just
-  // without a cached advance value (falls back to SD read).
-  static constexpr uint32_t MAX_ADVANCE_CODEPOINTS = 1024;
-  const uint32_t bufSize = (totalChars < MAX_ADVANCE_CODEPOINTS) ? totalChars : MAX_ADVANCE_CODEPOINTS;
-  uint32_t* codepoints = new (std::nothrow) uint32_t[bufSize];
-  if (!codepoints) {
-    LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate codepoint buffer (%u bytes)", bufSize * 4);
-    return -1;
-  }
-  uint32_t cpCount = 0;
-
-  // Second pass: collect unique codepoints via O(n²) dedup.
-  const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
-  while (*p && cpCount < bufSize) {
-    uint32_t cp = utf8NextCodepoint(&p);
-    if (cp == 0) break;
-
-    bool found = false;
-    for (uint32_t i = 0; i < cpCount; i++) {
-      if (codepoints[i] == cp) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      codepoints[cpCount++] = cp;
-    }
-  }
-
-  // Sort for ordered glyph index mapping and final table output
-  std::sort(codepoints, codepoints + cpCount);
-
-  // Step 2: Build per-style advance tables
   int totalMissed = 0;
   for (uint8_t si = 0; si < MAX_STYLES; si++) {
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
-    const auto& s = styles_[si];
+    const int missed = buildAdvanceTableForStyle(si, utf8Text);
+    if (missed > 0) totalMissed += missed;
+  }
 
-    // Map codepoints to global glyph indices
-    struct CpIdx {
-      uint32_t codepoint;
-      int32_t glyphIndex;
-    };
-    CpIdx* mappings = new (std::nothrow) CpIdx[cpCount];
-    if (!mappings) {
-      LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate mappings for style %u", si);
-      totalMissed += cpCount;
-      continue;
+  stats_.prewarmTotalMs = millis() - startMs;
+  return totalMissed;
+}
+
+// 1スタイルぶんの advance を、累積テーブルへ「足りないぶんだけ」追加する。
+// 必要なコードポイントが既に全部揃っていれば .cpfont を開かずに戻る。
+// 章の冒頭数ブロックを過ぎればこれが定常状態になり、SD I/O がほぼ消える。
+int SdCardFont::buildAdvanceTableForStyle(const uint8_t styleIdx, const char* utf8Text) {
+  const auto& s = styles_[styleIdx];
+
+  // Pass 1: 未取得のコードポイント数を数える（重複を含む上限値）。
+  // ゼロなら確保も I/O も一切せずに戻る。
+  uint32_t missUpperBound = 0;
+  {
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
+    while (*p) {
+      const uint32_t cp = utf8NextCodepoint(&p);
+      if (cp == 0) break;
+      if (!findAdvanceEntry(styleIdx, cp)) missUpperBound++;
     }
+  }
+  if (missUpperBound == 0) return 0;
+  if (missUpperBound > MAX_MISSES_PER_CALL) missUpperBound = MAX_MISSES_PER_CALL;
 
-    uint32_t validCount = 0;
-    for (uint32_t i = 0; i < cpCount; i++) {
-      int32_t idx = findGlobalGlyphIndex(s, codepoints[i]);
-      if (idx >= 0) {
-        mappings[validCount].codepoint = codepoints[i];
-        mappings[validCount].glyphIndex = idx;
-        validCount++;
-      }
-    }
-    totalMissed += static_cast<int>(cpCount - validCount);
+  struct Pending {
+    uint32_t codepoint;
+    int32_t glyphIndex;
+    uint16_t advanceX;
+    uint8_t hasGlyph;
+  };
+  const std::unique_ptr<Pending[]> pending(new (std::nothrow) Pending[missUpperBound]);
+  if (!pending) {
+    LOG_ERR("SDCF", "buildAdvanceTable: pending alloc failed (%u entries)", missUpperBound);
+    return -1;
+  }
 
-    if (validCount == 0) {
-      delete[] mappings;
-      continue;
-    }
-
-    // Allocate advance table
-    advanceTable_[si] = new (std::nothrow) AdvanceEntry[validCount];
-    if (!advanceTable_[si]) {
-      LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate advance table (%u entries) for style %u", validCount, si);
-      delete[] mappings;
-      continue;
-    }
-    advanceTableSize_[si] = validCount;
-
-    // Copy codepoints into advance table (already sorted)
-    for (uint32_t i = 0; i < validCount; i++) {
-      advanceTable_[si][i].codepoint = mappings[i].codepoint;
-      advanceTable_[si][i].advanceX = 0;
-    }
-
-    // Sort mappings by glyph index for sequential SD reads
-    std::sort(mappings, mappings + validCount,
-              [](const CpIdx& a, const CpIdx& b) { return a.glyphIndex < b.glyphIndex; });
-
-    // Build a reverse map: for each mapping index, find its position in the
-    // sorted-by-codepoint advance table. Since both are small and this runs
-    // once per section build, O(n²) is acceptable.
-    std::unique_ptr<uint32_t[]> tablePos(new (std::nothrow) uint32_t[validCount]);
-    if (!tablePos) {
-      LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate tablePos for style %u", si);
-      delete[] advanceTable_[si];
-      advanceTable_[si] = nullptr;
-      advanceTableSize_[si] = 0;
-      delete[] mappings;
-      continue;
-    }
-    for (uint32_t i = 0; i < validCount; i++) {
-      // Binary search the advance table (sorted by codepoint) for this mapping's codepoint
-      uint32_t lo = 0, hi = validCount;
-      while (lo < hi) {
-        uint32_t mid = lo + (hi - lo) / 2;
-        if (advanceTable_[si][mid].codepoint < mappings[i].codepoint) {
-          lo = mid + 1;
-        } else {
-          hi = mid;
+  // Pass 2: 未取得のコードポイントを重複除去して集める。
+  // 除去対象は未取得ぶんだけなので、O(n²) でも実際の件数は小さい。
+  uint32_t missCount = 0;
+  {
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8Text);
+    while (*p && missCount < missUpperBound) {
+      const uint32_t cp = utf8NextCodepoint(&p);
+      if (cp == 0) break;
+      if (findAdvanceEntry(styleIdx, cp)) continue;
+      bool dup = false;
+      for (uint32_t i = 0; i < missCount; i++) {
+        if (pending[i].codepoint == cp) {
+          dup = true;
+          break;
         }
       }
-      tablePos[i] = lo;
+      if (dup) continue;
+      pending[missCount].codepoint = cp;
+      pending[missCount].glyphIndex = findGlobalGlyphIndex(s, cp);  // RAM常駐の interval 表を引くだけ
+      pending[missCount].advanceX = 0;
+      pending[missCount].hasGlyph = 0;
+      missCount++;
     }
+  }
+  if (missCount == 0) return 0;
 
-    // Open file once, read advanceX for each glyph in index order
+  uint32_t withGlyph = 0;
+  for (uint32_t i = 0; i < missCount; i++) {
+    if (pending[i].glyphIndex >= 0) withGlyph++;
+  }
+  const int missed = static_cast<int>(missCount - withGlyph);
+
+  // Pass 3: グリフを持つものだけ SD から advanceX を読む。
+  // グリフ番号順に並べ替えることで、連続する番号では seek を省ける。
+  if (withGlyph > 0) {
+    std::sort(pending.get(), pending.get() + missCount,
+              [](const Pending& a, const Pending& b) { return a.glyphIndex < b.glyphIndex; });
+
     FsFile file;
     if (!Storage.openFileForRead("SDCF", filePath_, file)) {
-      LOG_ERR("SDCF", "buildAdvanceTable: failed to open .cpfont for style %u", si);
-      delete[] advanceTable_[si];
-      advanceTable_[si] = nullptr;
-      advanceTableSize_[si] = 0;
-      delete[] mappings;
-      continue;
+      LOG_ERR("SDCF", "buildAdvanceTable: failed to open .cpfont for style %u", styleIdx);
+      return missed;  // キャッシュに書かずに戻る。次の呼び出しで再試行される
     }
 
     EpdGlyph tempGlyph;
     int32_t lastReadIndex = INT32_MIN;
-    for (uint32_t i = 0; i < validCount; i++) {
-      int32_t gIdx = mappings[i].glyphIndex;
-      uint32_t fileOff = s.glyphsFileOffset + static_cast<uint32_t>(gIdx) * sizeof(EpdGlyph);
+    bool readError = false;
+    for (uint32_t i = 0; i < missCount; i++) {
+      const int32_t gIdx = pending[i].glyphIndex;
+      if (gIdx < 0) continue;  // ソート済みなので負の値は先頭に固まっている
+      const uint32_t fileOff = s.glyphsFileOffset + static_cast<uint32_t>(gIdx) * sizeof(EpdGlyph);
       if (gIdx != lastReadIndex + 1) {
         file.seekSet(fileOff);
       }
       if (file.read(reinterpret_cast<uint8_t*>(&tempGlyph), sizeof(EpdGlyph)) != sizeof(EpdGlyph)) {
-        LOG_ERR("SDCF", "buildAdvanceTable: short glyph read (style %u, glyph %d)", si, gIdx);
+        LOG_ERR("SDCF", "buildAdvanceTable: short glyph read (style %u, glyph %d)", styleIdx, gIdx);
+        readError = true;
         break;
       }
       lastReadIndex = gIdx;
-      advanceTable_[si][tablePos[i]].advanceX = tempGlyph.advanceX;
+      pending[i].advanceX = tempGlyph.advanceX;
+      pending[i].hasGlyph = 1;
     }
-
     file.close();
-    delete[] mappings;
 
-    LOG_DBG("SDCF", "Built advance table: style %u, %u entries, %u bytes", si, validCount,
-            validCount * static_cast<uint32_t>(sizeof(AdvanceEntry)));
+    // 途中で失敗したものを hasGlyph=0 でキャッシュすると「グリフ無し」として
+    // 固定されてしまう。読み直せるよう、何も登録せずに戻る。
+    if (readError) return missed;
   }
 
-  delete[] codepoints;
+  // Pass 4: コードポイント昇順に並べ替えて累積テーブルへマージする。
+  // グリフが無かったものも hasGlyph=0 で登録する（ネガティブキャッシュ）。
+  // これをしないと、フォントに無い字が出るたびに毎ブロック探索し直すことになる。
+  std::sort(pending.get(), pending.get() + missCount,
+            [](const Pending& a, const Pending& b) { return a.codepoint < b.codepoint; });
 
-  stats_.prewarmTotalMs = millis() - startMs;
-  return totalMissed;
+  if (ensureAdvanceCapacity(styleIdx, advanceTableSize_[styleIdx] + missCount)) {
+    // 後ろから詰めるインプレースマージ。pending は既存テーブルに無い要素のみなので重複しない。
+    AdvanceEntry* table = advanceTable_[styleIdx];
+    uint32_t i = advanceTableSize_[styleIdx];
+    uint32_t j = missCount;
+    uint32_t w = i + j;
+    while (j > 0) {
+      --w;
+      if (i > 0 && table[i - 1].codepoint > pending[j - 1].codepoint) {
+        table[w] = table[i - 1];
+        --i;
+      } else {
+        --j;
+        table[w].codepoint = pending[j].codepoint;
+        table[w].advanceX = pending[j].advanceX;
+        table[w].hasGlyph = pending[j].hasGlyph;
+      }
+    }
+    advanceTableSize_[styleIdx] += missCount;
+    return missed;
+  }
+
+  // 累積テーブルが上限に達した（または伸長に失敗した）。このブロックぶんだけ退避テーブルへ入れる。
+  // 累積ぶんは捨てないので、上限到達後も既知のコードポイントは引き続きヒットする。
+  auto* spill = static_cast<AdvanceEntry*>(malloc(missCount * sizeof(AdvanceEntry)));
+  if (!spill) {
+    LOG_ERR("SDCF", "advance spill alloc failed (style %u, %u entries)", styleIdx, missCount);
+    return missed;
+  }
+  for (uint32_t i = 0; i < missCount; i++) {
+    spill[i].codepoint = pending[i].codepoint;
+    spill[i].advanceX = pending[i].advanceX;
+    spill[i].hasGlyph = pending[i].hasGlyph;
+  }
+  free(advanceSpill_[styleIdx]);
+  advanceSpill_[styleIdx] = spill;
+  advanceSpillSize_[styleIdx] = missCount;
+  return missed;
 }
 
 // --- Stats ---

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -934,18 +934,19 @@ uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
   return entry ? entry->advanceX : 0;
 }
 
-bool SdCardFont::tryGetAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const {
+SdCardFont::AdvanceLookup SdCardFont::lookupAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const {
   if (style >= MAX_STYLES || (!advanceTable_[style] && !advanceSpill_[style])) {
     if (style != 0 && (advanceTable_[0] || advanceSpill_[0])) {
       style = 0;  // fallback to Regular
     } else {
-      return false;
+      return AdvanceLookup::NotCached;
     }
   }
   const AdvanceEntry* entry = findAdvanceEntry(style, codepoint);
-  if (!entry || !entry->hasGlyph) return false;
+  if (!entry) return AdvanceLookup::NotCached;
+  if (!entry->hasGlyph) return AdvanceLookup::NoGlyph;
   advanceOut = entry->advanceX;
-  return true;
+  return AdvanceLookup::Found;
 }
 
 // 累積テーブルを needed エントリぶん収容できるまで伸長する。
@@ -977,14 +978,19 @@ int SdCardFont::buildAdvanceTable(const char* utf8Text, uint8_t styleMask) {
   const unsigned long startMs = millis();
 
   int totalMissed = 0;
+  bool failed = false;
   for (uint8_t si = 0; si < MAX_STYLES; si++) {
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
     const int missed = buildAdvanceTableForStyle(si, utf8Text);
-    if (missed > 0) totalMissed += missed;
+    if (missed < 0) {
+      failed = true;
+    } else {
+      totalMissed += missed;
+    }
   }
 
   stats_.prewarmTotalMs = millis() - startMs;
-  return totalMissed;
+  return failed ? -1 : totalMissed;
 }
 
 // 1スタイルぶんの advance を、累積テーブルへ「足りないぶんだけ」追加する。
@@ -996,8 +1002,10 @@ int SdCardFont::buildAdvanceTableForStyle(const uint8_t styleIdx, const char* ut
   // グリフを持たない字は renderChar() が '?' を描くので、レイアウトもその幅に
   // 合わせる必要がある（GfxRenderer::getTextAdvanceX を参照）。参照できるよう
   // このスタイルの最初の構築時に '?' を必ずテーブルへ載せておく。
-  const bool seedFallbackGlyph = (advanceTableSize_[styleIdx] == 0);
-  const char* const segments[2] = {utf8Text, seedFallbackGlyph ? "?" : nullptr};
+  // '?' を先に置く。後ろに置くと、1回の呼び出しで新規コードポイントが
+  // MAX_MISSES_PER_CALL に達したときに '?' だけ取りこぼす。
+  const bool seedFallbackGlyph = (findAdvanceEntry(styleIdx, '?') == nullptr);
+  const char* const segments[2] = {seedFallbackGlyph ? "?" : nullptr, utf8Text};
 
   // Pass 1: 未取得のコードポイント数を数える（重複を含む上限値）。
   // ゼロなら確保も I/O も一切せずに戻る。

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -35,6 +35,11 @@ class SdCardFont {
   // Returns the 12.4 fixed-point advance, or 0 if not found.
   uint16_t getAdvance(uint32_t codepoint, uint8_t style) const;
 
+  // getAdvance() と同じ引数で、「テーブルに載っていて、かつフォントにグリフがある」
+  // 場合だけ true を返す。戻り値 0 が「幅0の字」なのか「グリフが無い字」なのかを
+  // 呼び出し側が区別できるようにするためのもの。
+  bool tryGetAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const;
+
   // Returns true if advance table is populated for at least one style.
   bool hasAdvanceTable() const;
 

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -35,10 +35,14 @@ class SdCardFont {
   // Returns the 12.4 fixed-point advance, or 0 if not found.
   uint16_t getAdvance(uint32_t codepoint, uint8_t style) const;
 
-  // getAdvance() と同じ引数で、「テーブルに載っていて、かつフォントにグリフがある」
-  // 場合だけ true を返す。戻り値 0 が「幅0の字」なのか「グリフが無い字」なのかを
-  // 呼び出し側が区別できるようにするためのもの。
-  bool tryGetAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const;
+  // advance テーブルの参照結果。getAdvance() が返す 0 の意味を呼び出し側が
+  // 区別できるようにするためのもの。
+  enum class AdvanceLookup : uint8_t {
+    NotCached,  // テーブルに載っていない（このテキスト用に構築されていない）
+    Found,      // グリフがあり advanceOut が有効（幅0の結合文字などもここ）
+    NoGlyph,    // フォントにグリフが無いと分かっている（renderChar は '?' を描く）
+  };
+  AdvanceLookup lookupAdvance(uint32_t codepoint, uint8_t style, uint16_t& advanceOut) const;
 
   // Returns true if advance table is populated for at least one style.
   bool hasAdvanceTable() const;
@@ -198,7 +202,10 @@ class SdCardFont {
   // 1セクションビルドあたり最大1回で済む。
   //
   // 寿命は clearAdvanceTables() まで。実際には clearCache() 経由で
-  // セクションビルドの直前に破棄される（EpubReaderActivity）。
+  // (a) セクションビルドの直前（EpubReaderActivity）と
+  // (b) 毎ページの描画前（FontCacheManager::PrewarmScope の ctor）
+  // に破棄される。つまり読書中に載りっぱなしにはならず、常駐するのは
+  // 1セクションビルド中および1ページ描画中だけ。
   struct AdvanceEntry {
     uint32_t codepoint;
     uint16_t advanceX;  // 12.4 fixed-point

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -185,13 +185,43 @@ class SdCardFont {
 
   // Compact advance-only table for layout measurement (per-style).
   // Built by buildAdvanceTable(), queried by getAdvance().
+  //
+  // エントリは呼び出しをまたいで**累積**する。レイアウトはテキストブロック
+  // （段落 または 400語）ごとに buildAdvanceTable() を呼ぶため、毎回作り直すと
+  // 同じ字を何度も .cpfont から読み直すことになる（Issue #99: 章ビルド時間の
+  // 88.8% がこれだった）。累積させることで、1コードポイントにつき SD 読みは
+  // 1セクションビルドあたり最大1回で済む。
+  //
+  // 寿命は clearAdvanceTables() まで。実際には clearCache() 経由で
+  // セクションビルドの直前に破棄される（EpubReaderActivity）。
   struct AdvanceEntry {
     uint32_t codepoint;
     uint16_t advanceX;  // 12.4 fixed-point
-  };
-  AdvanceEntry* advanceTable_[MAX_STYLES] = {};
+    uint8_t hasGlyph;   // 0 = このフォントにグリフが無い（ネガティブキャッシュ。再探索を防ぐ）
+  };  // アラインメント込みで 8 バイト
+
+  // 1スタイルあたりの上限。4096エントリ = 32KB。日本語の長編でも異なり字は
+  // 3,000字程度（JIS第1水準 ≒ 3,000）なので通常は到達しない。
+  static constexpr uint32_t ADVANCE_TABLE_INITIAL_CAP = 512;
+  static constexpr uint32_t ADVANCE_TABLE_MAX_CAP = 4096;
+  // 1回の呼び出しで新規に取得するコードポイント数の上限。
+  static constexpr uint32_t MAX_MISSES_PER_CALL = 1024;
+
+  AdvanceEntry* advanceTable_[MAX_STYLES] = {};  // コードポイント昇順。realloc で伸長するため malloc 系で管理
   uint32_t advanceTableSize_[MAX_STYLES] = {};
+  uint32_t advanceTableCap_[MAX_STYLES] = {};
+
+  // 累積テーブルが上限に達した（または伸長に失敗した）ときの退避先。
+  // buildAdvanceTable() の呼び出しごとに破棄されるブロックローカルのテーブル。
+  // これが無いと、上限到達の瞬間から全ブロックが「毎回作り直し」に戻る性能の崖ができる。
+  AdvanceEntry* advanceSpill_[MAX_STYLES] = {};
+  uint32_t advanceSpillSize_[MAX_STYLES] = {};
+
   void clearAdvanceTables();
+  void clearAdvanceSpill();
+  bool ensureAdvanceCapacity(uint8_t styleIdx, uint32_t needed);
+  const AdvanceEntry* findAdvanceEntry(uint8_t styleIdx, uint32_t codepoint) const;
+  int buildAdvanceTableForStyle(uint8_t styleIdx, const char* utf8Text);
 
   Stats stats_;
   uint32_t contentHash_ = 0;

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <vector>
 
+#include "SectionBuildPerf.h"
 #include "hyphenation/Hyphenator.h"
 
 namespace {
@@ -158,6 +159,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   if (words.empty()) {
     return;
   }
+  SECTION_PERF_SCOPE(layoutUs);
 
   // Apply fixed transforms before any per-line layout work.
   applyParagraphIndent();
@@ -168,6 +170,8 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   // (advanceX only, no bitmaps) for all unique codepoints in this paragraph so
   // that calculateWordWidths() can measure text without on-demand SD I/O.
   if (renderer.isSdCardFont(fontId)) {
+    SECTION_PERF_SCOPE(advanceUs);
+    SECTION_PERF_COUNT(advanceCalls);
     std::string allText;
     for (size_t i = 0; i < words.size(); i++) {
       if (i > 0) allText += ' ';
@@ -237,9 +241,12 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
                                        const std::function<void(std::shared_ptr<TextBlock>)>& processColumn,
                                        const bool includeLastColumn) {
   if (words.empty()) return;
+  SECTION_PERF_SCOPE(layoutUs);
 
   // Ensure SD card font metrics are loaded
   if (renderer.isSdCardFont(fontId)) {
+    SECTION_PERF_SCOPE(advanceUs);
+    SECTION_PERF_COUNT(advanceCalls);
     std::string allText;
     for (const auto& w : words) {
       allText += w;

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -75,6 +75,24 @@ uint16_t measureWordWidth(const GfxRenderer& renderer, const int fontId, const s
   return renderer.getTextAdvanceX(fontId, sanitized.c_str(), style);
 }
 
+// このブロックで実際に使われているフォントスタイルのビット集合を返す。
+// SDカードフォントの advance テーブルを、使わないスタイルのぶんまで
+// 構築してしまわないようにするためのもの（Issue #99）。
+//
+// UNDERLINE(4) は下線フラグであってスタイル番号ではない。SdCardFont::getAdvance() は
+// MAX_STYLES(4) 以上のスタイルを Regular にフォールバックさせるので、ここでも
+// 同じ扱いにして参照先を一致させる。
+// 幅の計測にはスペースや CJK インデント参照文字（いずれも REGULAR）も使うため、
+// REGULAR は常に含める。
+uint8_t usedStyleMask(const std::vector<EpdFontFamily::Style>& wordStyles) {
+  uint8_t mask = 1u << EpdFontFamily::REGULAR;
+  for (const auto style : wordStyles) {
+    const uint8_t idx = (style < EpdFontFamily::UNDERLINE) ? static_cast<uint8_t>(style) : 0;
+    mask |= static_cast<uint8_t>(1u << idx);
+  }
+  return mask;
+}
+
 // Check if a word is a single CJK character (used for zero-spacing between adjacent CJK words)
 bool isSingleCjkWord(const std::string& word) {
   if (word.empty()) return false;
@@ -178,7 +196,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
       allText += words[i];
     }
     if (hyphenationEnabled) allText += '-';
-    renderer.ensureSdCardFontReady(fontId, allText.c_str());
+    renderer.ensureSdCardFontReady(fontId, allText.c_str(), usedStyleMask(wordStyles));
   }
 
   const int pageWidth = viewportWidth;
@@ -252,7 +270,7 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
       allText += w;
       allText += ' ';
     }
-    renderer.ensureSdCardFontReady(fontId, allText.c_str());
+    renderer.ensureSdCardFontReady(fontId, allText.c_str(), usedStyleMask(wordStyles));
   }
 
   const int lineHeight = renderer.getLineHeight(fontId);

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -309,7 +309,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   if (cssParser) {
     cssParser->clear();
   }
-  SECTION_PERF_LOG(spineIndex, pageCount);
+  SECTION_PERF_LOG(spineIndex, pageCount, fontId, verticalMode);
   return true;
 }
 

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -7,6 +7,7 @@
 
 #include "Epub/css/CssParser.h"
 #include "Page.h"
+#include "SectionBuildPerf.h"
 #include "hyphenation/Hyphenator.h"
 #include "parsers/ChapterHtmlSlimParser.h"
 
@@ -30,7 +31,12 @@ uint32_t Section::onPageComplete(std::unique_ptr<Page> page) {
   }
 
   const uint32_t position = file.position();
-  if (!page->serialize(file)) {
+  bool serialized;
+  {
+    SECTION_PERF_SCOPE(serializeUs);
+    serialized = page->serialize(file);
+  }
+  if (!serialized) {
     LOG_ERR("SCT", "Failed to serialize page %d", pageCount);
     return 0;
   }
@@ -159,6 +165,8 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
                                 const bool verticalMode, const uint8_t charSpacing,
                                 const std::function<void()>& popupFn, const int* headingFontIds,
                                 const int tableFontId) {
+  SECTION_PERF_RESET();
+
   const auto localPath = epub->getSpineItem(spineIndex).href;
   const auto tmpHtmlPath = epub->getCachePath() + "/.tmp_" + std::to_string(spineIndex) + ".html";
 
@@ -171,6 +179,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   // Retry logic for SD card timing issues
   bool success = false;
   uint32_t fileSize = 0;
+  SECTION_PERF_BEGIN(extractStartUs);
   for (int attempt = 0; attempt < 3 && !success; attempt++) {
     if (attempt > 0) {
       LOG_DBG("SCT", "Retrying stream (attempt %d)...", attempt + 1);
@@ -196,6 +205,8 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
       LOG_DBG("SCT", "Removed incomplete temp file after failed attempt");
     }
   }
+  SECTION_PERF_END(extractStartUs, extractUs);
+  SECTION_PERF_SET(htmlBytes, fileSize);
 
   if (!success) {
     LOG_ERR("SCT", "Failed to stream item contents to temp file after retries");
@@ -298,6 +309,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   if (cssParser) {
     cssParser->clear();
   }
+  SECTION_PERF_LOG(spineIndex, pageCount);
   return true;
 }
 

--- a/lib/Epub/Epub/SectionBuildPerf.cpp
+++ b/lib/Epub/Epub/SectionBuildPerf.cpp
@@ -12,6 +12,9 @@ namespace {
 // 計測結果の追記先。カードを抜いて母艦で回収する前提。
 // .crosspoint/ は既存のキャッシュディレクトリなので、書籍一覧には現れない。
 constexpr char PERF_LOG_PATH[] = "/.crosspoint/index_perf.log";
+// 無条件に追記するため、際限なく育たないよう上限を設ける。
+// 1行約160バイトなので、400行ぶん残れば計測用途には十分。
+constexpr uint32_t PERF_LOG_MAX_BYTES = 64 * 1024;
 }  // namespace
 
 void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount, const int fontId, const bool verticalMode) {
@@ -27,15 +30,21 @@ void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount, const i
                p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000, p.advanceUs / 1000, p.advanceCalls,
                p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap(), esp_get_minimum_free_heap_size());
   if (len <= 0) return;
+  const size_t writeLen = (static_cast<size_t>(len) < sizeof(line)) ? static_cast<size_t>(len) : sizeof(line) - 1;
 
   LOG_DBG("SCT", "PERF %s", line);
 
   // SDへ追記。章ビルド1回につき1行なので、書き込み自体の所要時間は計測値に対して無視できる。
   auto file = Storage.open(PERF_LOG_PATH, O_WRONLY | O_CREAT | O_APPEND);
-  if (file) {
-    file.write(line, strnlen(line, sizeof(line)));
+  if (!file) return;
+  if (file.size() > PERF_LOG_MAX_BYTES) {
     file.close();
+    Storage.remove(PERF_LOG_PATH);
+    file = Storage.open(PERF_LOG_PATH, O_WRONLY | O_CREAT | O_APPEND);
+    if (!file) return;
   }
+  file.write(line, writeLen);
+  file.close();
 }
 
 #endif

--- a/lib/Epub/Epub/SectionBuildPerf.cpp
+++ b/lib/Epub/Epub/SectionBuildPerf.cpp
@@ -3,6 +3,7 @@
 #ifdef SECTION_BUILD_PERF
 
 #include <HalStorage.h>
+#include <esp_heap_caps.h>
 
 #include <cstdio>
 #include <cstring>
@@ -18,12 +19,13 @@ void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount, const i
 
   // 1行に収める。ミリ秒へ丸めて出力する（µs のままだと桁が読みにくいだけで精度は不要）。
   char line[256];
-  const int len = snprintf(line, sizeof(line),
-                           "t=%u spine=%d html=%u pages=%u font=%d vert=%d "
-                           "extract=%u read=%u parse=%u layout=%u adv=%u advn=%u img=%u pgser=%u heap=%u\n",
-                           millis(), spineIndex, p.htmlBytes, pageCount, fontId, verticalMode ? 1 : 0,
-                           p.extractUs / 1000, p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000, p.advanceUs / 1000,
-                           p.advanceCalls, p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap());
+  const int len =
+      snprintf(line, sizeof(line),
+               "t=%u spine=%d html=%u pages=%u font=%d vert=%d "
+               "extract=%u read=%u parse=%u layout=%u adv=%u advn=%u img=%u pgser=%u heap=%u minheap=%u\n",
+               millis(), spineIndex, p.htmlBytes, pageCount, fontId, verticalMode ? 1 : 0, p.extractUs / 1000,
+               p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000, p.advanceUs / 1000, p.advanceCalls,
+               p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap(), esp_get_minimum_free_heap_size());
   if (len <= 0) return;
 
   LOG_DBG("SCT", "PERF %s", line);

--- a/lib/Epub/Epub/SectionBuildPerf.cpp
+++ b/lib/Epub/Epub/SectionBuildPerf.cpp
@@ -1,0 +1,39 @@
+#include "SectionBuildPerf.h"
+
+#ifdef SECTION_BUILD_PERF
+
+#include <HalStorage.h>
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+// 計測結果の追記先。カードを抜いて母艦で回収する前提。
+// .crosspoint/ は既存のキャッシュディレクトリなので、書籍一覧には現れない。
+constexpr char PERF_LOG_PATH[] = "/.crosspoint/index_perf.log";
+}  // namespace
+
+void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount, const int fontId, const bool verticalMode) {
+  const SectionBuildPerf& p = gSectionBuildPerf;
+
+  // 1行に収める。ミリ秒へ丸めて出力する（µs のままだと桁が読みにくいだけで精度は不要）。
+  char line[256];
+  const int len = snprintf(line, sizeof(line),
+                           "t=%u spine=%d html=%u pages=%u font=%d vert=%d "
+                           "extract=%u read=%u parse=%u layout=%u adv=%u advn=%u img=%u pgser=%u heap=%u\n",
+                           millis(), spineIndex, p.htmlBytes, pageCount, fontId, verticalMode ? 1 : 0,
+                           p.extractUs / 1000, p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000, p.advanceUs / 1000,
+                           p.advanceCalls, p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap());
+  if (len <= 0) return;
+
+  LOG_DBG("SCT", "PERF %s", line);
+
+  // SDへ追記。章ビルド1回につき1行なので、書き込み自体の所要時間は計測値に対して無視できる。
+  auto file = Storage.open(PERF_LOG_PATH, O_WRONLY | O_CREAT | O_APPEND);
+  if (file) {
+    file.write(line, strnlen(line, sizeof(line)));
+    file.close();
+  }
+}
+
+#endif

--- a/lib/Epub/Epub/SectionBuildPerf.h
+++ b/lib/Epub/Epub/SectionBuildPerf.h
@@ -71,14 +71,13 @@ class ScopedPerfTimer {
   const uint32_t startUs;
 };
 
-inline void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount) {
-  const SectionBuildPerf& p = gSectionBuildPerf;
-  LOG_DBG("SCT",
-          "PERF spine=%d html=%uB pages=%u | extract=%ums read=%ums parse=%ums "
-          "(layout=%ums adv=%ums/n=%u img=%ums pgser=%ums) heap=%u",
-          spineIndex, p.htmlBytes, pageCount, p.extractUs / 1000, p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000,
-          p.advanceUs / 1000, p.advanceCalls, p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap());
-}
+// 計測結果を LOG_DBG と SDカード上のログファイル（PERF_LOG_PATH）の両方へ出力する。
+// ESP32-C3 の USB Serial/JTAG は実機動作中に切断されがちでシリアルが当てにならないため、
+// SD へ追記して後からカードを抜いて回収できるようにしている
+// （main.cpp の appendPowerLog が /.crosspoint/power_log.txt に対して行っているのと同じ手法）。
+// SDカードフォントかどうかは advn（advance テーブル構築の呼び出し回数）が
+// 0 より大きいかで判別できるため、専用のフラグは持たない。
+void logSectionBuildPerf(int spineIndex, uint32_t pageCount, int fontId, bool verticalMode);
 
 #define SECTION_PERF_CONCAT_INNER(a, b) a##b
 #define SECTION_PERF_CONCAT(a, b) SECTION_PERF_CONCAT_INNER(a, b)
@@ -92,7 +91,8 @@ inline void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount) 
 #define SECTION_PERF_COUNT(field) (++gSectionBuildPerf.field)
 #define SECTION_PERF_SET(field, value) (gSectionBuildPerf.field = (value))
 #define SECTION_PERF_RESET() gSectionBuildPerf.reset()
-#define SECTION_PERF_LOG(spineIndex, pageCount) logSectionBuildPerf((spineIndex), (pageCount))
+#define SECTION_PERF_LOG(spineIndex, pageCount, fontId, verticalMode) \
+  logSectionBuildPerf((spineIndex), (pageCount), (fontId), (verticalMode))
 
 #else
 
@@ -102,6 +102,6 @@ inline void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount) 
 #define SECTION_PERF_COUNT(field) ((void)0)
 #define SECTION_PERF_SET(field, value) ((void)0)
 #define SECTION_PERF_RESET() ((void)0)
-#define SECTION_PERF_LOG(spineIndex, pageCount) ((void)0)
+#define SECTION_PERF_LOG(spineIndex, pageCount, fontId, verticalMode) ((void)0)
 
 #endif

--- a/lib/Epub/Epub/SectionBuildPerf.h
+++ b/lib/Epub/Epub/SectionBuildPerf.h
@@ -1,0 +1,107 @@
+#pragma once
+
+// 章ビルド（インデックス）処理の内訳を計測するためのカウンタ群。
+//
+// 1章構成の巨大EPUBでインデックスが極端に遅い問題（Issue #99）の原因切り分け用。
+// 既存の計時ログ（ChapterHtmlSlimParser の "Time to parse and build pages"）は
+// パース・レイアウト・直列化の合計しか出さないため、どこが支配的なのか判断できない。
+//
+// 計測点の包含関係:
+//   章ビルド全体
+//   ├─ extractUs   zip -> .tmp_<n>.html への展開
+//   └─ parseUs     XML_ParseBuffer の累計（expatコールバック内の処理を含む）
+//      ├─ readUs   一時ファイルの read 累計（parseUs とは別枠、パースループ内）
+//      ├─ layoutUs   ParsedText の行分割・カラム分割（parseUs の内数）
+//      │  └─ advanceUs   SDカードフォントの advance テーブル構築（layoutUs の内数）
+//      ├─ imageUs    画像の抽出とデコード（parseUs の内数）
+//      └─ serializeUs  section.bin へのページ直列化（parseUs の内数）
+//
+// 注意: imageUs は画像タグの処理区間まるごとを測るため、その中で発生する
+// テキストブロックの flush（layoutUs）やページ直列化（serializeUs）と重複する。
+// 内訳の合計が parseUs を超えることがあるのは正常で、支配項の特定が目的。
+//
+// TextBlock::render() 内の advance 構築は描画時の処理でインデックス経路ではないため、
+// 意図的に計装していない（章ビルド中には呼ばれない）。
+//
+// LOG_DBG が有効なビルド（default 環境）でのみ実体を持ち、gh_release（LOG_LEVEL=1）や
+// slim（ENABLE_SERIAL_LOG なし）ではプリプロセッサで完全に消える。計測用の
+// micros() 呼び出しやカウンタ変数もリリースビルドには一切残らない。
+
+#if defined(ENABLE_SERIAL_LOG) && defined(LOG_LEVEL) && LOG_LEVEL >= 2
+#define SECTION_BUILD_PERF 1
+#endif
+
+#ifdef SECTION_BUILD_PERF
+
+#include <Arduino.h>
+#include <Logging.h>
+
+#include <cstdint>
+
+struct SectionBuildPerf {
+  uint32_t extractUs;
+  uint32_t readUs;
+  uint32_t parseUs;
+  uint32_t layoutUs;
+  uint32_t advanceUs;
+  uint32_t imageUs;
+  uint32_t serializeUs;
+  uint32_t advanceCalls;
+  uint32_t htmlBytes;
+
+  void reset() { *this = SectionBuildPerf{}; }
+};
+
+// C++20 の inline 変数。DBGビルドでのみ 36 バイトの DRAM を消費する。
+// 章ビルドは常に同期実行（サイレントインデックスも loop() 内で直列に走る）なので、
+// 単一のグローバルカウンタで競合しない。
+inline SectionBuildPerf gSectionBuildPerf{};
+
+// スコープを抜けるときに経過時間（µs）をカウンタへ加算する。
+// 早期 return の多い区間（画像処理など）でも取りこぼさないよう RAII にしている。
+class ScopedPerfTimer {
+ public:
+  explicit ScopedPerfTimer(uint32_t& target) : target(target), startUs(micros()) {}
+  ~ScopedPerfTimer() { target += micros() - startUs; }
+  ScopedPerfTimer(const ScopedPerfTimer&) = delete;
+  ScopedPerfTimer& operator=(const ScopedPerfTimer&) = delete;
+
+ private:
+  uint32_t& target;
+  const uint32_t startUs;
+};
+
+inline void logSectionBuildPerf(const int spineIndex, const uint32_t pageCount) {
+  const SectionBuildPerf& p = gSectionBuildPerf;
+  LOG_DBG("SCT",
+          "PERF spine=%d html=%uB pages=%u | extract=%ums read=%ums parse=%ums "
+          "(layout=%ums adv=%ums/n=%u img=%ums pgser=%ums) heap=%u",
+          spineIndex, p.htmlBytes, pageCount, p.extractUs / 1000, p.readUs / 1000, p.parseUs / 1000, p.layoutUs / 1000,
+          p.advanceUs / 1000, p.advanceCalls, p.imageUs / 1000, p.serializeUs / 1000, ESP.getFreeHeap());
+}
+
+#define SECTION_PERF_CONCAT_INNER(a, b) a##b
+#define SECTION_PERF_CONCAT(a, b) SECTION_PERF_CONCAT_INNER(a, b)
+
+// スコープ全体を計測する（早期 return があっても加算される）
+#define SECTION_PERF_SCOPE(field) \
+  const ScopedPerfTimer SECTION_PERF_CONCAT(perfTimer, __LINE__)(gSectionBuildPerf.field)
+// 単一の式だけを計測する（const 変数の初期化を挟みたい箇所向け）
+#define SECTION_PERF_BEGIN(name) const uint32_t name = micros()
+#define SECTION_PERF_END(name, field) gSectionBuildPerf.field += micros() - (name)
+#define SECTION_PERF_COUNT(field) (++gSectionBuildPerf.field)
+#define SECTION_PERF_SET(field, value) (gSectionBuildPerf.field = (value))
+#define SECTION_PERF_RESET() gSectionBuildPerf.reset()
+#define SECTION_PERF_LOG(spineIndex, pageCount) logSectionBuildPerf((spineIndex), (pageCount))
+
+#else
+
+#define SECTION_PERF_SCOPE(field) ((void)0)
+#define SECTION_PERF_BEGIN(name) ((void)0)
+#define SECTION_PERF_END(name, field) ((void)0)
+#define SECTION_PERF_COUNT(field) ((void)0)
+#define SECTION_PERF_SET(field, value) ((void)0)
+#define SECTION_PERF_RESET() ((void)0)
+#define SECTION_PERF_LOG(spineIndex, pageCount) ((void)0)
+
+#endif

--- a/lib/Epub/Epub/SectionBuildPerf.h
+++ b/lib/Epub/Epub/SectionBuildPerf.h
@@ -71,10 +71,13 @@ class ScopedPerfTimer {
   const uint32_t startUs;
 };
 
-// 計測結果を LOG_DBG と SDカード上のログファイル（PERF_LOG_PATH）の両方へ出力する。
-// ESP32-C3 の USB Serial/JTAG は実機動作中に切断されがちでシリアルが当てにならないため、
-// SD へ追記して後からカードを抜いて回収できるようにしている
-// （main.cpp の appendPowerLog が /.crosspoint/power_log.txt に対して行っているのと同じ手法）。
+// 計測結果を LOG_DBG と SDカード上のログファイル（/.crosspoint/index_perf.log）の
+// 両方へ出力する。ESP32-C3 の USB Serial/JTAG は実機動作中に切断されがちで
+// シリアルが当てにならないため、SD へ追記して後からカードを抜いて回収できるようにしている。
+//
+// main.cpp の appendPowerLog も同じくSDへ追記するが、あちらは SETTINGS.debugDisplay で
+// ガードされているのに対し、こちらはガードしていない（lib から src の設定を参照できないため）。
+// 代わりにこのビルド自体が LOG_LEVEL>=2 限定であることと、ファイルサイズ上限で歯止めをかける。
 // SDカードフォントかどうかは advn（advance テーブル構築の呼び出し回数）が
 // 0 より大きいかで判別できるため、専用のフラグは持たない。
 void logSectionBuildPerf(int spineIndex, uint32_t pageCount, int fontId, bool verticalMode);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -60,7 +60,9 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
       if (!rt.empty()) allRuby += rt;
     }
     if (!allRuby.empty()) {
-      renderer.ensureSdCardFontReady(rubyFontId, allRuby.c_str());
+      // ルビは常に REGULAR で描画する（下の drawText/drawTextVertical 参照）。
+      // 全スタイルを要求すると、使わない Bold のぶんまで .cpfont を読むことになる。
+      renderer.ensureSdCardFontReady(rubyFontId, allRuby.c_str(), 1u << EpdFontFamily::REGULAR);
     }
   }
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -10,6 +10,7 @@
 
 #include "../../Epub.h"
 #include "../Page.h"
+#include "../SectionBuildPerf.h"
 #include "../blocks/TableRowBlock.h"
 #include "../blocks/TextBlock.h"
 #include "../converters/ImageDecoderFactory.h"
@@ -338,6 +339,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   }
 
   if (matches(name, IMAGE_TAGS, NUM_IMAGE_TAGS)) {
+    SECTION_PERF_SCOPE(imageUs);
     std::string src;
     std::string alt;
     if (atts != nullptr) {
@@ -1270,7 +1272,9 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       return false;
     }
 
+    SECTION_PERF_BEGIN(readStartUs);
     const size_t len = file.read(buf, PARSE_BUFFER_SIZE);
+    SECTION_PERF_END(readStartUs, readUs);
 
     if (len == 0 && file.available() > 0) {
       LOG_ERR("EHP", "File read error");
@@ -1284,7 +1288,11 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
 
     done = file.available() == 0;
 
-    if (XML_ParseBuffer(parser, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+    SECTION_PERF_BEGIN(parseStartUs);
+    const XML_Status parseStatus = XML_ParseBuffer(parser, static_cast<int>(len), done);
+    SECTION_PERF_END(parseStartUs, parseUs);
+
+    if (parseStatus == XML_STATUS_ERROR) {
       LOG_ERR("EHP", "Parse error at line %lu:\n%s", XML_GetCurrentLineNumber(parser),
               XML_ErrorString(XML_GetErrorCode(parser)));
       XML_StopParser(parser, XML_FALSE);                // Stop any pending processing

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1659,18 +1659,26 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
   if (sdIt != sdCardFonts_.end() && sdIt->second->hasAdvanceTable()) {
     int32_t widthFP = 0;
     const uint8_t styleIdx = static_cast<uint8_t>(style);
-    // フォントにグリフが無い字は renderChar() が '?' を描く。幅もそれに合わせないと
-    // レイアウトが実際の描画より狭く見積もられ、行からはみ出す。
+    // フォントにグリフが無いと分かっている字は renderChar() が '?' を描く。幅もそれに
+    // 合わせないとレイアウトが実際の描画より狭く見積もられ、行からはみ出す。
     // （builtinGlyphAdvanceX が組み込みフォントに対して担保しているのと同じ整合性）
     int32_t fallbackFP = -1;
     while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&text))) {
-      uint16_t advance;
-      if (sdIt->second->tryGetAdvance(cp, styleIdx, advance)) {
-        widthFP += advance;
-        continue;
+      uint16_t advance = 0;
+      switch (sdIt->second->lookupAdvance(cp, styleIdx, advance)) {
+        case SdCardFont::AdvanceLookup::Found:
+          widthFP += advance;
+          break;
+        case SdCardFont::AdvanceLookup::NoGlyph:
+          if (fallbackFP < 0) fallbackFP = sdIt->second->getAdvance('?', styleIdx);
+          widthFP += fallbackFP;
+          break;
+        case SdCardFont::AdvanceLookup::NotCached:
+          // このテキスト用にテーブルが用意されていない場合は従来どおり 0 のままにする。
+          // ここで '?' 幅を足すと、ルビ先読み直後の TextBlock::render が
+          // 参照字 "一" を測るときに columnWidth を壊してしまう。
+          break;
       }
-      if (fallbackFP < 0) fallbackFP = sdIt->second->getAdvance('?', styleIdx);
-      widthFP += fallbackFP;
     }
     const uint16_t scale = getSdCardFontScale(fontId);
     if (scale != 256) {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1659,8 +1659,18 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
   if (sdIt != sdCardFonts_.end() && sdIt->second->hasAdvanceTable()) {
     int32_t widthFP = 0;
     const uint8_t styleIdx = static_cast<uint8_t>(style);
+    // フォントにグリフが無い字は renderChar() が '?' を描く。幅もそれに合わせないと
+    // レイアウトが実際の描画より狭く見積もられ、行からはみ出す。
+    // （builtinGlyphAdvanceX が組み込みフォントに対して担保しているのと同じ整合性）
+    int32_t fallbackFP = -1;
     while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&text))) {
-      widthFP += sdIt->second->getAdvance(cp, styleIdx);
+      uint16_t advance;
+      if (sdIt->second->tryGetAdvance(cp, styleIdx, advance)) {
+        widthFP += advance;
+        continue;
+      }
+      if (fallbackFP < 0) fallbackFP = sdIt->second->getAdvance('?', styleIdx);
+      widthFP += fallbackFP;
     }
     const uint16_t scale = getSdCardFontScale(fontId);
     if (scale != 256) {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -168,14 +168,19 @@ const uint8_t* GfxRenderer::getGlyphBitmap(const EpdFontData* fontData, const Ep
   return &fontData->bitmap[glyph->dataOffset];
 }
 
-void GfxRenderer::ensureSdCardFontReady(int fontId, const char* utf8Text) const {
+void GfxRenderer::ensureSdCardFontReady(int fontId, const char* utf8Text, uint8_t styleMask) const {
   auto it = sdCardFonts_.find(fontId);
   if (it != sdCardFonts_.end()) {
     // Build a compact advance-only table for layout measurement.
     // Unlike prewarm(), this has no codepoint limit — handles CJK paragraphs
     // with 2000+ unique codepoints without overflow thrashing.
-    // Uses 6 bytes per codepoint (vs 16 for full EpdGlyph), no bitmap data.
-    int missed = it->second->buildAdvanceTable(utf8Text, 0x0F);
+    // Uses 8 bytes per codepoint (vs 16 for full EpdGlyph), no bitmap data.
+    //
+    // styleMask には「このテキストで実際に使うスタイル」だけを渡すこと。
+    // 全スタイル（0x0F）を渡すと、本文が Regular だけの段落でも Bold のぶんまで
+    // .cpfont を開いて読むことになる（本フォークの CJK フォントは Regular + Bold
+    // の2スタイル持ちなので、そのまま2倍のコストになる）。
+    int missed = it->second->buildAdvanceTable(utf8Text, styleMask);
     if (missed > 0) {
       LOG_DBG("GFX", "ensureSdCardFontReady: %d glyph(s) not found", missed);
     }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -124,7 +124,9 @@ class GfxRenderer {
   bool isSdCardFont(int fontId) const { return sdCardFonts_.count(fontId) > 0; }
   // Ensure SD card font glyph data is loaded for the given text. Called from layout code
   // (which holds a const GfxRenderer&) before measuring word widths. Safe to call on non-SD fonts (no-op).
-  void ensureSdCardFontReady(int fontId, const char* utf8Text) const;
+  // styleMask は「このテキストで実際に使うスタイル」のビット集合（1 << EpdFontFamily::Style）。
+  // 既定の 0x0F は全スタイル。レイアウト経路からは使用スタイルに絞って渡すこと。
+  void ensureSdCardFontReady(int fontId, const char* utf8Text, uint8_t styleMask = 0x0F) const;
 
   // Orientation control (affects logical width/height and coordinate
   // transforms)


### PR DESCRIPTION
Closes #99

## 概要

1章構成の巨大EPUBでインデックスが極端に遅い問題を、まず計測してから対処した。

実機計測の結果、章ビルド時間の **88.8%** が `SdCardFont::buildAdvanceTable()` だった。これを解消し、**同一条件で 172.6秒 → 28.9秒（6.0倍）** になった。

## 実測結果

日本語の長編小説、spine=1、縦書き、SDカードフォント、347KBの章 / 668ページ。
`html` / `pages` / `font` / `vert` が前後で完全一致しているので同一条件の比較。

| 区間 | 修正前 | 修正後 | 倍率 |
|---|---:|---:|---:|
| **章ビルド合計** | **172,567 ms** | **28,912 ms** | **6.0x** |
| advance準備 | 153,302 ms | 10,895 ms | 14.1x |
| ページ直列化 | 8,637 ms | 7,701 ms | 1.1x |
| expat/コールバック | 4,160 ms | 3,902 ms | 1.1x |
| 純粋なレイアウト | 3,305 ms | 3,225 ms | 1.0x |
| zip展開 | 3,163 ms | 3,189 ms | 1.0x |
| 一時ファイル読み | 911 ms | 703 ms | 1.3x |

advance以外の区間がすべて誤差範囲で一致しており、変更点が正しく分離できていることの裏付けになっている。

RAM: サマリ時点のヒープ 137,048 → 120,780（差 15.9KB が累積キャッシュぶん）。起動以来の最小空きヒープ 61,528（60.1KB）で、セクションビルドの下限 50KB に対して余裕がある。累積テーブルは `PrewarmScope` が毎ページ描画前に破棄するため、読書中に載りっぱなしにはならない。

## 原因

`buildAdvanceTable()` が冒頭で `clearAdvanceTables()` して前ブロックの結果を毎回捨てていた。日本語の長編で使われる異なり字は2,500字程度なのに、2,404ブロックそれぞれが自分のぶんを `.cpfont` を開き直して 1グリフ16バイトずつ seek+read していた。1回あたり 63.8ms。

さらに本フォークのCJKフォントは Regular + Bold の2スタイル持ちで、`ensureSdCardFontReady` が `styleMask` に `0x0F` を固定で渡していたため、本文がRegularだけの段落でもBoldぶんまで構築していた（そのまま2倍のコスト）。

Issue本文が挙げていた3つの見立て（一時ファイル全展開・1KBパースバッファ・章内分割なし）は、コード上は正しかったが**性能への寄与はいずれも数%以下**だった。計測せずにバッファを膨らませていても何も変わらなかった。

## 変更内容

### 計測（Step 1）
- `SectionBuildPerf.h` / `.cpp` を追加。zip展開 / ファイル読み / パース / レイアウト / advance構築 / 画像 / 直列化を個別計測し、章ビルド完了時に1行のサマリを出す
- `ENABLE_SERIAL_LOG && LOG_LEVEL >= 2` ガード付き。`gh_release` の RAM が master と完全一致することで、リリースビルドから消えることを確認済み
- 実機でシリアルが使えないため、`LOG_DBG` に加えて `/.crosspoint/index_perf.log` へ追記する（64KB上限つき）

### 高速化（Step 2）
- advance テーブルを呼び出しまたぎで**累積**させ、足りないぶんだけ読む。必要な字が揃っていれば `.cpfont` を開かずに戻る
- `ensureSdCardFontReady` に `styleMask` を追加し、`ParsedText` から実際に使うスタイルだけを渡す
- グリフを持たない字も `hasGlyph=0` で登録（ネガティブキャッシュ）
- `realloc` で伸長、上限4096エントリ（32KB/スタイル）。上限到達時はブロックローカルの退避テーブルへ入れ、「一度超えたら全ブロックが元の速度に戻る」性能の崖を作らない
- O(n²) の重複除去は未取得ぶんだけが対象になり実質消滅

### 既存バグの修正
`getTextAdvanceX` のSDカードフォント高速パスが `getAdvance()` の 0 を無検査で加算していたため、**フォントにグリフが無い字がレイアウト上は幅ゼロ**になっていた（`renderChar` は '?' を描くので実際の描画とズレる）。三値の `lookupAdvance()` を追加し、グリフが無いと分かっている字には '?' の幅を使う。

`SdCardFont.cpp` のコメントは「onGlyphMiss() でSDから読まれる」と書いていたが、`onGlyphMiss` は描画経路専用でレイアウト経路からは呼ばれない。

## 動作確認

- [x] `pio run`（LOG_LEVEL=2）成功、新規警告なし
- [x] `pio run -e gh_release` 成功。RAM は master と同一、Flash +1,698B（修正本体ぶん。計装は消えている）
- [x] clang-format 適用済み
- [x] 実機で 172.6秒 → 28.9秒 を確認（縦書き・SDカードフォント）
- [ ] **縦書き＋ルビ＋縦中横を含むページの表示確認**（レビュー指摘 H1 の回帰確認。最終コミットで根治済みだが実機未確認）
- [ ] 横書き・内蔵フォントでの表示確認

## 残課題（本PRの対象外）

- 残る advance 10.9秒。計測スコープに含まれる `allText` の `std::string` 連結（`reserve` なし）と、ブロックごとの全文字再スキャンが主因と見ている
- 元のIssueが対象とする「1章構成の数MB EPUB」では、`extract` / `pgser` / `expat` がサイズに比例して残るため依然として遅い可能性がある。該当する本での計測が必要
- 下線付き太字が「計測 Regular / 描画 Bold」で幅がズレる既存問題（master にも存在）。両側を `style & 0x03` に揃えるべき

🤖 Generated with [Claude Code](https://claude.com/claude-code)

