### PR TITLE
fix: 電書協テンプレートCSSのEPUBで発生するメモリエラーを解消する

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -346,8 +346,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   // Try to load existing cache first
   if (bookMetadataCache->load()) {
     if (!skipLoadingCss) {
-      // Rebuild CSS cache when missing or when cache version changed (loadFromCache removes stale file)
-      if (!cssParser->hasCache() || !cssParser->loadFromCache()) {
+      // Rebuild CSS cache when missing or when cache version changed (validateCache removes stale file).
+      // validateCache() only checks the header; rules are loaded into RAM per
+      // section during section building, not held for the whole session.
+      if (!cssParser->validateCache()) {
         LOG_DBG("EBP", "CSS rules cache missing or stale, attempting to parse CSS files");
         cssParser->deleteCache();
 

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -6,6 +6,7 @@
 #include <Serialization.h>
 
 #include "Epub/css/CssParser.h"
+#include "Epub/css/CssSelectorUsage.h"
 #include "Page.h"
 #include "SectionBuildPerf.h"
 #include "hyphenation/Hyphenator.h"
@@ -232,7 +233,14 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   if (embeddedStyle) {
     cssParser = epub->getCssParser();
     if (cssParser) {
-      if (!cssParser->loadFromCache()) {
+      // Load only the cached rules this chapter can actually reference.
+      // Generic publisher stylesheets (e.g. the EBPAJ template) register
+      // hundreds of rules of which a chapter uses a handful; loading them all
+      // costs tens of KB of heap right when section building needs it most
+      // (issue #105). If the scan fails, fall back to loading everything.
+      CssSelectorUsage usage;
+      const bool scanned = usage.scanHtmlFile(tmpHtmlPath);
+      if (!cssParser->loadFromCache(scanned ? &usage : nullptr)) {
         LOG_ERR("SCT", "Failed to load CSS from cache");
       }
     }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -8,6 +8,8 @@
 #include <cctype>
 #include <string_view>
 
+#include "CssSelectorUsage.h"
+
 namespace {
 
 // Stack-allocated string buffer to avoid heap reallocations during parsing
@@ -761,7 +763,31 @@ bool CssParser::saveToCache() const {
   return true;
 }
 
-bool CssParser::loadFromCache() {
+bool CssParser::validateCache() const {
+  if (cachePath.empty()) {
+    return false;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("CSS", cachePath + rulesCache, file)) {
+    return false;
+  }
+
+  uint8_t version = 0;
+  if (file.read(&version, 1) != 1 || version != CssParser::CSS_CACHE_VERSION) {
+    LOG_DBG("CSS", "Cache version mismatch (got %u, expected %u), removing stale cache for rebuild", version,
+            CssParser::CSS_CACHE_VERSION);
+    // Explicitly close() file before calling Storage.remove()
+    file.close();
+    Storage.remove((cachePath + rulesCache).c_str());
+    return false;
+  }
+
+  file.close();
+  return true;
+}
+
+bool CssParser::loadFromCache(const CssSelectorUsage* usage) {
   if (cachePath.empty()) {
     return false;
   }
@@ -918,9 +944,16 @@ bool CssParser::loadFromCache() {
     style.defined.imageWidth = (definedBits & 1 << 14) != 0;
     style.defined.display = (definedBits & 1 << 15) != 0;
 
+    // Skip rules that can never match the scanned document; the style
+    // payload has already been consumed from the stream at this point.
+    if (usage != nullptr && !usage->matches(selector)) {
+      continue;
+    }
+
     rulesBySelector_[selector] = style;
   }
 
-  LOG_DBG("CSS", "Loaded %u rules from cache", ruleCount);
+  LOG_DBG("CSS", "Loaded %zu of %u cached rules%s", rulesBySelector_.size(), ruleCount,
+          usage != nullptr ? " (usage-filtered)" : "");
   return true;
 }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -382,6 +382,11 @@ CssStyle CssParser::parseDeclarations(const std::string& declBlock) {
 // Rule processing
 
 void CssParser::processRuleBlockWithStyle(const std::string& selectorGroup, const CssStyle& style) {
+  // Skip rules that don't define any supported properties to save RAM.
+  if (!style.defined.anySet()) {
+    return;
+  }
+
   // Check if we've reached the rule limit before processing
   if (rulesBySelector_.size() >= MAX_RULES) {
     LOG_DBG("CSS", "Reached max rules limit (%zu), stopping CSS parsing", MAX_RULES);

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -31,7 +31,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 4;
+  static constexpr uint8_t CSS_CACHE_VERSION = 5;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -9,6 +9,8 @@
 
 #include "CssStyle.h"
 
+class CssSelectorUsage;
+
 /**
  * Lightweight CSS parser for EPUB stylesheets
  *
@@ -99,9 +101,19 @@ class CssParser {
   /**
    * Load CSS rules from a cache file.
    * Clears any existing rules before loading.
+   * @param usage Optional filter: only rules whose selector can match the
+   *        scanned document are kept in RAM. Pass nullptr to load all rules.
    * @return true if cache was loaded successfully
    */
-  bool loadFromCache();
+  bool loadFromCache(const CssSelectorUsage* usage = nullptr);
+
+  /**
+   * Check that the cache file exists and matches CSS_CACHE_VERSION without
+   * materializing any rules in RAM. Removes a stale cache file (version
+   * mismatch) just like loadFromCache().
+   * @return true if a usable cache file is present
+   */
+  bool validateCache() const;
 
  private:
   // Storage: maps normalized selector -> style properties

--- a/lib/Epub/Epub/css/CssSelectorUsage.cpp
+++ b/lib/Epub/Epub/css/CssSelectorUsage.cpp
@@ -1,0 +1,229 @@
+#include "CssSelectorUsage.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+
+#include <cctype>
+
+namespace {
+
+// Buffer size for streaming the HTML file (matches CssParser::loadFromStream)
+constexpr size_t READ_BUFFER_SIZE = 512;
+
+bool isNameChar(const char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == ':';
+}
+
+bool isHtmlWhitespace(const char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'; }
+
+}  // namespace
+
+bool CssSelectorUsage::contains(const std::vector<std::string>& list, const std::string_view name) {
+  for (const auto& entry : list) {
+    if (entry == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void CssSelectorUsage::addTag(const std::string_view name) {
+  if (name.empty() || overflowed_ || contains(tags_, name)) {
+    return;
+  }
+  if (tags_.size() >= MAX_TAGS) {
+    overflowed_ = true;
+    return;
+  }
+  tags_.emplace_back(name);
+}
+
+void CssSelectorUsage::addClass(const std::string_view name) {
+  if (name.empty() || overflowed_ || contains(classes_, name)) {
+    return;
+  }
+  if (classes_.size() >= MAX_CLASSES) {
+    overflowed_ = true;
+    return;
+  }
+  classes_.emplace_back(name);
+}
+
+bool CssSelectorUsage::matches(const std::string& selectorKey) const {
+  if (overflowed_) {
+    return true;
+  }
+  const std::string_view key(selectorKey);
+  const size_t dot = key.find('.');
+  if (dot == std::string_view::npos) {
+    return containsTag(key);
+  }
+  if (dot == 0) {
+    return containsClass(key.substr(1));
+  }
+  // "tag.class" — both parts must be present in the document.
+  // Keys with multiple dots (e.g. "p.a.b") are unreachable by resolveStyle()
+  // and correctly fail the class lookup here.
+  return containsTag(key.substr(0, dot)) && containsClass(key.substr(dot + 1));
+}
+
+bool CssSelectorUsage::scanHtmlFile(const std::string& path) {
+  FsFile file;
+  if (!Storage.openFileForRead("CSU", path, file)) {
+    return false;
+  }
+
+  // Minimal streaming markup scanner. EPUB chapters are well-formed XHTML,
+  // so attribute values are always quoted; everything else (comments,
+  // processing instructions, closing tags) is skipped. Over-collection from
+  // odd markup is harmless — it only means loading a few extra CSS rules.
+  enum class State : uint8_t {
+    Text,           // outside any markup
+    TagOpen,        // just consumed '<'
+    SkipMarkup,     // "</", "<!", "<?" — ignore until '>'
+    TagName,        // reading the element name
+    InTag,          // inside a tag, between attributes
+    AttrName,       // reading an attribute name
+    AfterAttrName,  // after attribute name, before '=' or the next attribute
+    BeforeValue,    // after '=', before the opening quote
+    AttrValue,      // inside a quoted attribute value
+  };
+
+  State state = State::Text;
+  char token[MAX_TOKEN_LENGTH];
+  size_t tokenLen = 0;
+  bool tokenOverflow = false;
+  bool inClassAttr = false;
+  char quoteChar = '"';
+
+  const auto tokenView = [&]() { return std::string_view(token, tokenLen); };
+  const auto resetToken = [&]() {
+    tokenLen = 0;
+    tokenOverflow = false;
+  };
+  const auto appendToken = [&](const char c) {
+    if (tokenLen < sizeof(token)) {
+      token[tokenLen++] = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    } else {
+      // Token longer than any realistic tag/class name; drop it rather than
+      // record a truncated name that could spuriously match a shorter rule.
+      tokenOverflow = true;
+    }
+  };
+
+  char buffer[READ_BUFFER_SIZE];
+  while (file.available()) {
+    const int bytesRead = file.read(buffer, sizeof(buffer));
+    if (bytesRead <= 0) {
+      break;
+    }
+    for (int i = 0; i < bytesRead; ++i) {
+      const char c = buffer[i];
+      switch (state) {
+        case State::Text:
+          if (c == '<') {
+            state = State::TagOpen;
+          }
+          break;
+        case State::TagOpen:
+          if (c == '/' || c == '!' || c == '?') {
+            state = State::SkipMarkup;
+          } else if (std::isalpha(static_cast<unsigned char>(c))) {
+            resetToken();
+            appendToken(c);
+            state = State::TagName;
+          } else {
+            state = State::Text;
+          }
+          break;
+        case State::SkipMarkup:
+          if (c == '>') {
+            state = State::Text;
+          }
+          break;
+        case State::TagName:
+          if (isNameChar(c)) {
+            appendToken(c);
+          } else {
+            if (!tokenOverflow) {
+              addTag(tokenView());
+            }
+            state = (c == '>') ? State::Text : State::InTag;
+          }
+          break;
+        case State::InTag:
+          if (c == '>') {
+            state = State::Text;
+          } else if (std::isalpha(static_cast<unsigned char>(c))) {
+            resetToken();
+            appendToken(c);
+            state = State::AttrName;
+          }
+          break;
+        case State::AttrName:
+          if (isNameChar(c)) {
+            appendToken(c);
+          } else {
+            inClassAttr = !tokenOverflow && tokenView() == "class";
+            if (c == '=') {
+              state = State::BeforeValue;
+            } else if (c == '>') {
+              state = State::Text;
+            } else {
+              state = State::AfterAttrName;
+            }
+          }
+          break;
+        case State::AfterAttrName:
+          if (c == '=') {
+            state = State::BeforeValue;
+          } else if (c == '>') {
+            state = State::Text;
+          } else if (std::isalpha(static_cast<unsigned char>(c))) {
+            resetToken();
+            appendToken(c);
+            state = State::AttrName;
+          }
+          break;
+        case State::BeforeValue:
+          if (c == '"' || c == '\'') {
+            quoteChar = c;
+            resetToken();
+            state = State::AttrValue;
+          } else if (c == '>') {
+            state = State::Text;
+          } else if (!isHtmlWhitespace(c)) {
+            // Unquoted value — invalid in XHTML; skip it as generic tag content
+            state = State::InTag;
+          }
+          break;
+        case State::AttrValue:
+          if (c == quoteChar) {
+            if (inClassAttr && !tokenOverflow) {
+              addClass(tokenView());
+            }
+            state = State::InTag;
+          } else if (inClassAttr) {
+            if (isHtmlWhitespace(c)) {
+              if (!tokenOverflow) {
+                addClass(tokenView());
+              }
+              resetToken();
+            } else {
+              appendToken(c);
+            }
+          }
+          break;
+      }
+    }
+  }
+  file.close();
+
+  // ChapterHtmlSlimParser resolves "img" styles for image elements regardless
+  // of the source tag name (e.g. SVG <image>), so always keep img rules.
+  addTag("img");
+
+  LOG_DBG("CSU", "Scanned %s: %zu tags, %zu classes%s", path.c_str(), tags_.size(), classes_.size(),
+          overflowed_ ? " (overflow, fail-open)" : "");
+  return true;
+}

--- a/lib/Epub/Epub/css/CssSelectorUsage.h
+++ b/lib/Epub/Epub/css/CssSelectorUsage.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+/**
+ * Collects the set of tag names and class names actually used by a chapter's
+ * (X)HTML document, so CSS cache loading can skip rules that can never match.
+ *
+ * CssParser::resolveStyle() only ever looks up "tag", ".class" and
+ * "tag.class" keys, so a cached rule is worth loading into RAM iff its tag
+ * and class parts appear somewhere in the document. Generic publisher
+ * stylesheets (e.g. the EBPAJ template used by most Japanese EPUBs) register
+ * hundreds of rules of which a typical chapter references a handful; skipping
+ * the rest keeps tens of KB of heap free during section building (issue #105).
+ */
+class CssSelectorUsage {
+ public:
+  /**
+   * Stream the (X)HTML file at path and record used tag and class names.
+   * @return false if the file could not be opened; callers should then fall
+   *         back to loading the full CSS cache.
+   */
+  bool scanHtmlFile(const std::string& path);
+
+  /**
+   * Whether a CSS cache key ("tag", ".class" or "tag.class") can match this
+   * document. Fails open (returns true) when the collection overflowed.
+   */
+  [[nodiscard]] bool matches(const std::string& selectorKey) const;
+
+  [[nodiscard]] size_t tagCount() const { return tags_.size(); }
+  [[nodiscard]] size_t classCount() const { return classes_.size(); }
+
+ private:
+  // Caps keep pathological documents from growing the sets unbounded;
+  // on overflow we fail open and matches() accepts every rule.
+  static constexpr size_t MAX_TAGS = 64;
+  static constexpr size_t MAX_CLASSES = 256;
+  static constexpr size_t MAX_TOKEN_LENGTH = 128;
+
+  void addTag(std::string_view name);
+  void addClass(std::string_view name);
+  [[nodiscard]] bool containsTag(std::string_view name) const { return contains(tags_, name); }
+  [[nodiscard]] bool containsClass(std::string_view name) const { return contains(classes_, name); }
+  static bool contains(const std::vector<std::string>& list, std::string_view name);
+
+  // Small sets (tens of entries) held as flat vectors with linear lookup;
+  // an unordered_set would cost one heap node per entry for no gain here.
+  std::vector<std::string> tags_;
+  std::vector<std::string> classes_;
+  bool overflowed_ = false;
+};


### PR DESCRIPTION
## 概要

Issue #105（X3で電書協テンプレートCSSを使ったEPUBを開くと「メモリエラー」になる）への対処です。2段階の修正でセクション構築時のCSSメモリ常駐を削減します。

## 原因

「メモリエラー」は `Section::createSectionFile()` の失敗時に表示されます（`EpubReaderActivity.cpp:885`）。セクション構築時にはCSSキャッシュの全ルールが `unordered_map` にロードされ、その直後のヒープ事前チェック（`MIN_FREE_HEAP_FOR_SECTION_BUILD = 50KB`）で不足すると失敗します。

Issue添付のテスト用EPUB（電書協テンプレートCSS 4ファイル・計約144KB）をCssParserのフィルタロジックをホスト側で再現して測定した結果:

| 状態 | 登録ルール数 | RAM常駐（概算） |
|---|---:|---:|
| 修正前 | 853 | 約110KB |
| 1コミット目適用後 | 469 | 約62KB |
| 2コミット目適用後（セクション構築時） | 十数ルール | 数KB |

登録ルールの97%超は本文から一度も参照されません。

## 変更内容

### 1. 解釈できないCSSルールをRAMに保存しない（本家PR crosspoint-reader/crosspoint-reader#2604 の取り込み）

対応プロパティ（`text-align`, `margin` 等）を1つも含まないルールを登録しないようにする `anySet()` チェックを追加。`CSS_CACHE_VERSION` を 4→5 にバンプし、既存キャッシュは自動再生成されます。

### 2. 章が参照しないCSSルールをRAMにロードしない（フォーク独自）

- **`CssSelectorUsage` を新設**: 抽出済みの章HTMLをストリーミング走査（固定512Bバッファ）し、使用タグ・クラス集合を収集
- **`CssParser::loadFromCache()` にフィルタ追加**: `resolveStyle()` が参照しうるキー（`tag` / `.class` / `tag.class`）が使用集合にマッチするルールだけをRAMにロード。走査失敗時は全ロードにフォールバック（fail-open）
- **`Epub::load()` の検証を軽量化**: 従来はキャッシュ検証のために全ルールをロードしたまま読書セッション中ずっと常駐させていたため、ヘッダのみ確認する `validateCache()` に変更

CSSの解釈結果自体は変わりません（ロードされないのは当該章から参照不可能なルールのみ）。

## Done 判定基準

- [x] `pio run`（default環境）ビルド成功
- [x] clang-format適用済み
- [x] 実機（X3）でIssue #105のテスト用EPUBが「書籍の埋め込みスタイル: ON」のまま開けること
- [x] 既存の書籍（横書き・縦書き）でレイアウト崩れがないこと
- [x] キャッシュ再生成後の2回目以降のオープンも正常なこと

※ 実機検証が必要です。検証完了までIssue #105はクローズしません。

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
