### PR TITLE
fix: 新しいX3 (UC8279) で画面が更新されない問題に対応する

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "open-x4-sdk"]
 	path = open-x4-sdk
-	url = https://github.com/crosspoint-reader/community-sdk.git
+	url = https://github.com/zrn-ns/community-sdk.git

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -137,7 +137,12 @@ class GfxRenderer {
   void setFadingFix(const bool enabled) { fadingFix = enabled; }
 
   // Dark mode control
-  void setDarkMode(bool darkMode) { this->darkMode = darkMode; }
+  void setDarkMode(bool darkMode) {
+    this->darkMode = darkMode;
+    // Keep the panel driver's dark-background hint in sync (consumed by the
+    // UC8279 differential fast path; a no-op on other controllers).
+    display.setDarkBackgroundHint(darkMode);
+  }
   bool isDarkMode() const { return darkMode; }
   // When true, images are inverted along with text in dark mode.
   // When false (default), image rendering skips dark mode inversion.

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -14,6 +14,9 @@ void HalDisplay::begin() {
   // Set X3-specific panel mode before initializing.
   if (gpio.deviceIsX3()) {
     einkDisplay.setDisplayX3();
+    if (gpio.x3DisplayIsUc8279()) {
+      einkDisplay.setDisplayX3Uc8279();
+    }
   }
 
   einkDisplay.begin();
@@ -67,6 +70,8 @@ void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen
 }
 
 void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
+
+void HalDisplay::setDarkBackgroundHint(bool darkBackground) { einkDisplay.setBackgroundHint(darkBackground); }
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -39,6 +39,10 @@ class HalDisplay {
   // Power management
   void deepSleep();
 
+  // Forward the dark-background hint to the panel driver (consumed by the
+  // UC8279 differential fast path; a no-op elsewhere).
+  void setDarkBackgroundHint(bool darkBackground);
+
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -204,6 +204,25 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 constexpr char NVS_KEY_EPD_OVERRIDE[] = "epd_ovr";  // 0=auto, 1=uc8253, 2=uc8279
 constexpr char NVS_KEY_EPD_CACHED[] = "epd_det";    // 0=unknown, 1=uc8253, 2=uc8279
 
+constexpr size_t EPD_MTP_DUMP_LEN = 48;
+
+// Snapshot of the last controller decision, kept so main() can replay the
+// diagnostics AFTER Serial.begin() — the probe itself runs in gpio.begin(),
+// before serial is up, so anything logged there never reaches the monitor.
+struct ProbeDiag {
+  enum class Source : uint8_t { None = 0, Override, Cached, Probe };
+  Source source = Source::None;
+  bool uc8279 = false;
+  uint8_t verdict = 0;  // X3EpdProbe::Verdict when source == Probe
+  uint8_t ver[5] = {0};
+  uint8_t flg = 0;
+  uint8_t mtp[EPD_MTP_DUMP_LEN] = {0};
+  bool mtpValid = false;
+  bool oemScreenTypeSet = false;
+  uint8_t oemScreenType = 0;
+};
+ProbeDiag g_epdProbeDiag;
+
 namespace X3EpdProbe {
 
 // UC81xx read-capable registers (UC8179 / UC8279d datasheets, identical
@@ -212,9 +231,9 @@ constexpr uint8_t UC81XX_CMD_VER = 0x70;   // reserved 0x00, CHIP_VER, LUT_VER[2
 constexpr uint8_t UC81XX_CMD_FLG = 0x71;   // status; BUSY_N (D0) = 1 when idle
 constexpr uint8_t UC81XX_CMD_RMTP = 0xA2;  // bulk MTP read: 1 dummy byte, then MTP[0..n]
 
-constexpr size_t MTP_DUMP_LEN = 48;
+constexpr size_t MTP_DUMP_LEN = EPD_MTP_DUMP_LEN;
 
-inline void clockDelay() { delayMicroseconds(1); }  // ~500 kHz, timing-safe
+inline void clockDelay() { delayMicroseconds(1); }  // <= ~500 kHz (upper bound), timing-safe
 
 void writeByte(uint8_t b) {
   for (uint8_t i = 0; i < 8; i++) {
@@ -249,8 +268,11 @@ void cmdRead(uint8_t cmd, uint8_t* out, uint8_t len) {
   digitalWrite(EPD_CS, LOW);
   clockDelay();
   writeByte(cmd);
-  digitalWrite(EPD_DC, HIGH);
+  // Release SDA BEFORE raising DC (deliberate swap vs the freeink reference,
+  // which raises DC first): once DC is high the controller may start driving
+  // the line, and pinMode() is slow enough to leave a contention window.
   pinMode(EPD_MOSI, INPUT_PULLUP);
+  digitalWrite(EPD_DC, HIGH);
   clockDelay();
   for (uint8_t i = 0; i < len; i++) {
     out[i] = readByte();
@@ -283,15 +305,6 @@ bool matchUc81xx(const uint8_t ver[5], uint8_t flg) {
 }
 
 bool runProbePass(uint8_t ver[5], uint8_t* flg, uint8_t rstLowMs) {
-  // The deep-sleep path isolates RTC-capable GPIOs (0-5 on the C3, which
-  // includes EPD_DC=4 and EPD_RST=5) and enables per-pin holds that survive
-  // the wake reset. Release them, or every digitalWrite below silently
-  // bounces off the retained latch and the probe reads garbage. CS (21) is
-  // outside the RTC range but the call is free.
-  gpio_hold_dis(static_cast<gpio_num_t>(EPD_RST));
-  gpio_hold_dis(static_cast<gpio_num_t>(EPD_DC));
-  gpio_hold_dis(static_cast<gpio_num_t>(EPD_CS));
-
   pinMode(EPD_CS, OUTPUT);
   digitalWrite(EPD_CS, HIGH);
   pinMode(EPD_SCLK, OUTPUT);
@@ -323,13 +336,17 @@ bool runProbePass(uint8_t ver[5], uint8_t* flg, uint8_t rstLowMs) {
 }
 
 void releasePins() {
-  // Leave everything released. RST_N has an internal pull-up, so INPUT keeps
-  // the controller out of reset.
+  // Leave the data pins released; EInkDisplay::begin() reconfigures them.
   pinMode(EPD_SCLK, INPUT);
   pinMode(EPD_MOSI, INPUT);
   pinMode(EPD_CS, INPUT_PULLUP);  // don't leave the panel selected
   pinMode(EPD_DC, INPUT);
-  pinMode(EPD_RST, INPUT);
+  // Keep RST actively driven HIGH (deliberate divergence from the freeink
+  // reference, which floats it): EInkDisplay::begin() may be seconds away
+  // (SD init, font scan, button settle), and a floating reset input burns
+  // current in the input buffer and relies on an assumed internal pull-up.
+  pinMode(EPD_RST, OUTPUT);
+  digitalWrite(EPD_RST, HIGH);
 }
 
 enum class Verdict : uint8_t { Uc8253Assumed, Uc8279Confirmed, Inconclusive };
@@ -360,12 +377,12 @@ Verdict probeController() {
   // returns a dummy byte then MTP[0..n]. On a confirmed part it's
   // diagnostics; on the fallback path below it is the discriminator itself.
   // A part without RMTP (UC8253) floats the line and reads uniform garbage.
-  uint8_t mtp[MTP_DUMP_LEN] = {0};
+  uint8_t* mtp = g_epdProbeDiag.mtp;
   bool mtpValid = false;
   if (confirmed || flgDriven) {
     uint8_t raw[MTP_DUMP_LEN + 1] = {0};
     cmdRead(UC81XX_CMD_RMTP, raw, sizeof(raw));
-    memcpy(mtp, raw + 1, sizeof(mtp));
+    memcpy(mtp, raw + 1, MTP_DUMP_LEN);
     mtpValid = true;
   }
 
@@ -387,20 +404,27 @@ Verdict probeController() {
     verdict = Verdict::Uc8253Assumed;
   }
 
-  const uint8_t* ver = (pass1 && pass2) ? ver2 : ver1;
-  LOG_INF("XTDET", "bus probe VER=%02X %02X %02X %02X %02X FLG=%02X -> %s", ver[0], ver[1], ver[2], ver[3], ver[4],
-          flg1,
-          verdict == Verdict::Uc8279Confirmed ? "UltraChip"
-          : verdict == Verdict::Uc8253Assumed ? "default controller"
-                                              : "inconclusive (default)");
-  if (mtpValid) {
-    char mtpHex[MTP_DUMP_LEN * 3 + 1];
-    for (size_t i = 0; i < MTP_DUMP_LEN; i++) {
-      snprintf(&mtpHex[i * 3], 4, " %02X", mtp[i]);
-    }
-    LOG_INF("XTDET", "MTP[0x000..0x02F]:%s", mtpHex);
-  }
+  // Persist the raw probe evidence for the post-Serial.begin() replay (the
+  // probe runs before serial is up, so anything logged here only reaches the
+  // RTC ring buffer). Keeping the hex formatting out of this frame also keeps
+  // its stack usage within the 256-byte local-variable guideline.
+  memcpy(g_epdProbeDiag.ver, (pass1 && pass2) ? ver2 : ver1, 5);
+  g_epdProbeDiag.flg = flg1;
+  g_epdProbeDiag.mtpValid = mtpValid;
+  g_epdProbeDiag.verdict = static_cast<uint8_t>(verdict);
+  LOG_INF("XTDET", "bus probe verdict=%u", static_cast<unsigned>(verdict));
   return verdict;
+}
+
+const char* verdictName(uint8_t v) {
+  switch (static_cast<Verdict>(v)) {
+    case Verdict::Uc8279Confirmed:
+      return "UltraChip";
+    case Verdict::Uc8253Assumed:
+      return "default controller";
+    default:
+      return "inconclusive (default)";
+  }
 }
 
 }  // namespace X3EpdProbe
@@ -408,37 +432,38 @@ Verdict probeController() {
 bool detectX3DisplayIsUc8279() {
   const NvsDeviceValue overrideValue = readNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
   if (overrideValue != NvsDeviceValue::Unknown) {
-    LOG_INF("XTDET", "EPD controller override active: %s", overrideValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
-    return overrideValue == NvsDeviceValue::X3;
+    g_epdProbeDiag.source = ProbeDiag::Source::Override;
+    g_epdProbeDiag.uc8279 = overrideValue == NvsDeviceValue::X3;
+    return g_epdProbeDiag.uc8279;
   }
 
   const NvsDeviceValue cachedValue = readNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
   if (cachedValue != NvsDeviceValue::Unknown) {
-    LOG_INF("XTDET", "Using cached EPD controller: %s", cachedValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
-    return cachedValue == NvsDeviceValue::X3;
+    g_epdProbeDiag.source = ProbeDiag::Source::Cached;
+    g_epdProbeDiag.uc8279 = cachedValue == NvsDeviceValue::X3;
+    return g_epdProbeDiag.uc8279;
   }
 
   // The OEM records the panel controller in NVS hw_calib/screenType, but a
-  // full-flash from another unit can overwrite it — log it for diagnostics,
-  // never decide on it. The live bus probe is the ground truth.
+  // full-flash from another unit can overwrite it — capture it for
+  // diagnostics, never decide on it. The live bus probe is the ground truth.
   {
     Preferences prefs;
     if (prefs.begin("hw_calib", true)) {
       if (prefs.isKey("screenType")) {
-        LOG_INF("XTDET", "NVS hw_calib/screenType=%u [info only]", prefs.getUChar("screenType", 0));
-      } else {
-        LOG_INF("XTDET", "NVS hw_calib/screenType: not set [info only]");
+        g_epdProbeDiag.oemScreenTypeSet = true;
+        g_epdProbeDiag.oemScreenType = prefs.getUChar("screenType", 0);
       }
       prefs.end();
-    } else {
-      LOG_INF("XTDET", "NVS hw_calib/screenType: not set [info only]");
     }
   }
 
+  g_epdProbeDiag.source = ProbeDiag::Source::Probe;
   const X3EpdProbe::Verdict verdict = X3EpdProbe::probeController();
   if (verdict == X3EpdProbe::Verdict::Uc8279Confirmed) {
     LOG_INF("XTDET", "promoted UC8253 -> UC8279");
     writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::X3);
+    g_epdProbeDiag.uc8279 = true;
     return true;
   }
   if (verdict == X3EpdProbe::Verdict::Uc8253Assumed) {
@@ -456,6 +481,16 @@ bool detectX3DisplayIsUc8279() {
 void HalGPIO::begin() {
   inputMgr.begin();
 
+  // The deep-sleep path (esp_sleep_config_gpio_isolate + gpio_deep_sleep_hold_en)
+  // may leave per-pin holds on the EPD pins; whether they survive the wake
+  // reset on the C3 is disputed (the IDF note says digital pads reset, the
+  // freeink bench found the RST hold sticking), so release them here
+  // unconditionally — the calls are free and this keeps every boot identical
+  // regardless of whether the probe below runs or hits its NVS cache.
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_RST));
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_DC));
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_CS));
+
   // Device fingerprint is I2C-only, so it can run before SPI comes up. The
   // panel-controller probe bit-bangs the EPD pins, so it MUST run before
   // SPI.begin() attaches them to the SPI matrix.
@@ -470,19 +505,69 @@ void HalGPIO::begin() {
   }
 }
 
-void HalGPIO::toggleX3DisplayControllerOverride() {
+HalGPIO::EpdOverride HalGPIO::toggleX3DisplayControllerOverride() {
+  // Three-state cycle: auto -> force UC8253 -> force UC8279 -> auto. Both
+  // forced states must be reachable by buttons alone: a UC8253 unit
+  // misdetected as UC8279 needs force-UC8253, and a UC8279 unit whose probe
+  // stays Inconclusive (e.g. an FLG variant the matcher rejects) needs
+  // force-UC8279 — neither can navigate a settings UI with a dead screen.
+  // The forced states take effect in-RAM immediately (display init runs
+  // after this); returning to auto only takes effect next boot, because SPI
+  // already owns the EPD pins and re-probing now is unsafe.
   const NvsDeviceValue current = readNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
-  if (current == NvsDeviceValue::X4) {
-    // Force-UC8253 already active: back to auto, drop the cache so the next
-    // boot re-probes. The in-RAM flag stays false for this boot (SPI already
-    // owns the EPD pins, re-probing now is unsafe).
-    writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
-    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
-    LOG_INF("XTDET", "EPD override cleared -> auto-detect on next boot");
-  } else {
+  if (current == NvsDeviceValue::Unknown) {
     writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::X4);
     _x3DisplayIsUc8279 = false;
-    LOG_INF("XTDET", "EPD override set -> force UC8253");
+    LOG_INF("XTDET", "EPD override -> force UC8253");
+    return EpdOverride::ForceUc8253;
+  }
+  if (current == NvsDeviceValue::X4) {
+    writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::X3);
+    _x3DisplayIsUc8279 = true;
+    LOG_INF("XTDET", "EPD override -> force UC8279");
+    return EpdOverride::ForceUc8279;
+  }
+  // Force-UC8279 active: back to auto, drop the cache so the next boot
+  // re-probes from scratch.
+  writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
+  writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
+  LOG_INF("XTDET", "EPD override cleared -> auto-detect on next boot");
+  return EpdOverride::Auto;
+}
+
+void HalGPIO::logX3DisplayProbeDiag() const {
+  // Replays the panel-controller decision for the serial monitor; the
+  // decision itself was made in begin(), before Serial.begin().
+  if (!deviceIsX3() || g_epdProbeDiag.source == ProbeDiag::Source::None) {
+    return;
+  }
+  switch (g_epdProbeDiag.source) {
+    case ProbeDiag::Source::Override:
+      LOG_INF("XTDET", "EPD controller override active: %s", g_epdProbeDiag.uc8279 ? "UC8279" : "UC8253");
+      return;
+    case ProbeDiag::Source::Cached:
+      LOG_INF("XTDET", "Using cached EPD controller: %s", g_epdProbeDiag.uc8279 ? "UC8279" : "UC8253");
+      return;
+    default:
+      break;
+  }
+  if (g_epdProbeDiag.oemScreenTypeSet) {
+    LOG_INF("XTDET", "NVS hw_calib/screenType=%u [info only]", g_epdProbeDiag.oemScreenType);
+  } else {
+    LOG_INF("XTDET", "NVS hw_calib/screenType: not set [info only]");
+  }
+  const uint8_t* ver = g_epdProbeDiag.ver;
+  LOG_INF("XTDET", "bus probe VER=%02X %02X %02X %02X %02X FLG=%02X -> %s", ver[0], ver[1], ver[2], ver[3], ver[4],
+          g_epdProbeDiag.flg, X3EpdProbe::verdictName(g_epdProbeDiag.verdict));
+  if (g_epdProbeDiag.mtpValid) {
+    char mtpHex[EPD_MTP_DUMP_LEN * 3 + 1];
+    for (size_t i = 0; i < EPD_MTP_DUMP_LEN; i++) {
+      snprintf(&mtpHex[i * 3], 4, " %02X", g_epdProbeDiag.mtp[i]);
+    }
+    LOG_INF("XTDET", "MTP[0x000..0x02F]:%s", mtpHex);
+  }
+  if (g_epdProbeDiag.uc8279) {
+    LOG_INF("XTDET", "promoted UC8253 -> UC8279");
   }
 }
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -3,7 +3,10 @@
 #include <Preferences.h>
 #include <SPI.h>
 #include <Wire.h>
+#include <driver/gpio.h>
 #include <esp_sleep.h>
+
+#include <cstring>
 
 // Global HalGPIO instance
 HalGPIO gpio;
@@ -188,17 +191,298 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
   return HalGPIO::DeviceType::X4;
 }
 
+// --- X3 panel-controller fingerprint (UC8253 vs UC8279d) --------------------
+// Newer X3 production units ship a UC8279d panel controller on the same
+// board, glass and pins (Issue #109). Ported from freeink-sdk XteinkDetect:
+// a half-duplex 4-wire SPI probe bit-banged on the EPD pins reads the
+// UC8279's VER (0x70) and FLG (0x71) registers after a reset pulse. The
+// UC8253 answers neither, so its bus floats to a uniform level. MUST run
+// before SPI.begin() attaches the pins to the SPI matrix.
+//
+// Result caching reuses NvsDeviceValue: 1 (X4) = UC8253, 2 (X3) = UC8279 —
+// the same value mapping upstream CrossPoint uses for these keys.
+constexpr char NVS_KEY_EPD_OVERRIDE[] = "epd_ovr";  // 0=auto, 1=uc8253, 2=uc8279
+constexpr char NVS_KEY_EPD_CACHED[] = "epd_det";    // 0=unknown, 1=uc8253, 2=uc8279
+
+namespace X3EpdProbe {
+
+// UC81xx read-capable registers (UC8179 / UC8279d datasheets, identical
+// layout). The UC8253 has none of them.
+constexpr uint8_t UC81XX_CMD_VER = 0x70;   // reserved 0x00, CHIP_VER, LUT_VER[23:0]
+constexpr uint8_t UC81XX_CMD_FLG = 0x71;   // status; BUSY_N (D0) = 1 when idle
+constexpr uint8_t UC81XX_CMD_RMTP = 0xA2;  // bulk MTP read: 1 dummy byte, then MTP[0..n]
+
+constexpr size_t MTP_DUMP_LEN = 48;
+
+inline void clockDelay() { delayMicroseconds(1); }  // ~500 kHz, timing-safe
+
+void writeByte(uint8_t b) {
+  for (uint8_t i = 0; i < 8; i++) {
+    digitalWrite(EPD_MOSI, (b & 0x80) ? HIGH : LOW);
+    clockDelay();
+    digitalWrite(EPD_SCLK, HIGH);
+    clockDelay();
+    digitalWrite(EPD_SCLK, LOW);
+    b <<= 1;
+  }
+}
+
+uint8_t readByte() {
+  uint8_t b = 0;
+  for (uint8_t i = 0; i < 8; i++) {
+    // The controller shifts the next bit out on the SCL falling edge; sample
+    // while the clock is low, then pulse.
+    clockDelay();
+    b = static_cast<uint8_t>((b << 1) | (digitalRead(EPD_MOSI) == HIGH ? 1 : 0));
+    digitalWrite(EPD_SCLK, HIGH);
+    clockDelay();
+    digitalWrite(EPD_SCLK, LOW);
+  }
+  return b;
+}
+
+// One command + N-byte half-duplex read: command with DC low, then SDA (our
+// MOSI) released to input with DC high while the controller drives the reads.
+void cmdRead(uint8_t cmd, uint8_t* out, uint8_t len) {
+  pinMode(EPD_MOSI, OUTPUT);
+  digitalWrite(EPD_DC, LOW);
+  digitalWrite(EPD_CS, LOW);
+  clockDelay();
+  writeByte(cmd);
+  digitalWrite(EPD_DC, HIGH);
+  pinMode(EPD_MOSI, INPUT_PULLUP);
+  clockDelay();
+  for (uint8_t i = 0; i < len; i++) {
+    out[i] = readByte();
+  }
+  digitalWrite(EPD_CS, HIGH);
+  pinMode(EPD_MOSI, OUTPUT);
+}
+
+// A released SDA reads back all-0x00 or all-0xFF through the pull-up; any
+// variation across the five VER bytes means a real, driven response.
+bool verIsFloating(const uint8_t ver[5]) {
+  for (int i = 1; i < 5; i++) {
+    if (ver[i] != ver[0]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool matchUc81xx(const uint8_t ver[5], uint8_t flg) {
+  // FLG must be a real, non-floating status with BUSY_N (bit0) asserted
+  // (idle), and VER an actually-driven (non-uniform) pattern.
+  if (flg == 0x00 || flg == 0xFF) {
+    return false;
+  }
+  if ((flg & 0x01) != 0x01) {
+    return false;
+  }
+  return !verIsFloating(ver);
+}
+
+bool runProbePass(uint8_t ver[5], uint8_t* flg, uint8_t rstLowMs) {
+  // The deep-sleep path isolates RTC-capable GPIOs (0-5 on the C3, which
+  // includes EPD_DC=4 and EPD_RST=5) and enables per-pin holds that survive
+  // the wake reset. Release them, or every digitalWrite below silently
+  // bounces off the retained latch and the probe reads garbage. CS (21) is
+  // outside the RTC range but the call is free.
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_RST));
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_DC));
+  gpio_hold_dis(static_cast<gpio_num_t>(EPD_CS));
+
+  pinMode(EPD_CS, OUTPUT);
+  digitalWrite(EPD_CS, HIGH);
+  pinMode(EPD_SCLK, OUTPUT);
+  digitalWrite(EPD_SCLK, LOW);
+  pinMode(EPD_DC, OUTPUT);
+  digitalWrite(EPD_DC, LOW);
+  pinMode(EPD_MOSI, OUTPUT);
+  pinMode(EPD_BUSY, INPUT);
+
+  // Hardware reset pulse. We can't trust BUSY polarity here — the controller
+  // (and therefore its idle level) is exactly what we're trying to identify —
+  // so a flat settle delay covers every UC81xx power-up. EInkDisplay::begin()
+  // resets again afterwards, so this leaves no state behind.
+  pinMode(EPD_RST, OUTPUT);
+  digitalWrite(EPD_RST, HIGH);
+  delay(2);
+  digitalWrite(EPD_RST, LOW);
+  delay(rstLowMs);
+  digitalWrite(EPD_RST, HIGH);
+  delay(30);
+
+  uint8_t flgByte = 0;
+  cmdRead(UC81XX_CMD_FLG, &flgByte, 1);
+  cmdRead(UC81XX_CMD_VER, ver, 5);
+  if (flg != nullptr) {
+    *flg = flgByte;
+  }
+  return matchUc81xx(ver, flgByte);
+}
+
+void releasePins() {
+  // Leave everything released. RST_N has an internal pull-up, so INPUT keeps
+  // the controller out of reset.
+  pinMode(EPD_SCLK, INPUT);
+  pinMode(EPD_MOSI, INPUT);
+  pinMode(EPD_CS, INPUT_PULLUP);  // don't leave the panel selected
+  pinMode(EPD_DC, INPUT);
+  pinMode(EPD_RST, INPUT);
+}
+
+enum class Verdict : uint8_t { Uc8253Assumed, Uc8279Confirmed, Inconclusive };
+
+// Two-pass probe with agreement. Confirmed only when both passes match the
+// UC81xx signature AND agree on the VER bytes — a floating bus can't produce
+// the same stable non-trivial pattern twice. Reset budget: pass 1 screens
+// with a short 1 ms reset, escalating once to the vendor-identification
+// timing (RST low 50 ms) on failure; pass 2 confirms at 50 ms only when
+// pass 1 matched.
+Verdict probeController() {
+  uint8_t ver1[5] = {0};
+  uint8_t ver2[5] = {0};
+  uint8_t flg1 = 0;
+  bool pass1 = runProbePass(ver1, &flg1, /*rstLowMs=*/1);
+  if (!pass1) {
+    delay(2);
+    pass1 = runProbePass(ver1, &flg1, /*rstLowMs=*/50);
+  }
+  delay(2);
+  const bool pass2 = runProbePass(ver2, nullptr, /*rstLowMs=*/pass1 ? 50 : 1);
+
+  const bool verAgree = memcmp(ver1, ver2, 5) == 0;
+  bool confirmed = pass1 && pass2 && verAgree;
+  const bool flgDriven = flg1 != 0x00 && flg1 != 0xFF && (flg1 & 0x01) == 0x01;
+
+  // Ground-truth dump of the module's factory configuration: RMTP (0xA2)
+  // returns a dummy byte then MTP[0..n]. On a confirmed part it's
+  // diagnostics; on the fallback path below it is the discriminator itself.
+  // A part without RMTP (UC8253) floats the line and reads uniform garbage.
+  uint8_t mtp[MTP_DUMP_LEN] = {0};
+  bool mtpValid = false;
+  if (confirmed || flgDriven) {
+    uint8_t raw[MTP_DUMP_LEN + 1] = {0};
+    cmdRead(UC81XX_CMD_RMTP, raw, sizeof(raw));
+    memcpy(mtp, raw + 1, sizeof(mtp));
+    mtpValid = true;
+  }
+
+  // Fallback match — field-observed UC8279d signature: some units return
+  // VER = FF FF FF FF FF (blank/unreadable LUT_VER area) with a driven FLG,
+  // which the uniform-VER floating-bus test wrongly rejects. A pulled-up
+  // floating bus also reads FF — so require POSITIVE evidence: the RMTP dump
+  // must start with the 0xA5 MTP key, which only a real UC81xx with a
+  // programmed MTP can produce. The UC8253 has no RMTP command.
+  if (!confirmed && flgDriven && verAgree && verIsFloating(ver1) && ver1[0] == 0xFF && mtpValid && mtp[0] == 0xA5) {
+    confirmed = true;
+  }
+  releasePins();
+
+  Verdict verdict = Verdict::Inconclusive;
+  if (confirmed) {
+    verdict = Verdict::Uc8279Confirmed;
+  } else if (!pass1 && !pass2) {
+    verdict = Verdict::Uc8253Assumed;
+  }
+
+  const uint8_t* ver = (pass1 && pass2) ? ver2 : ver1;
+  LOG_INF("XTDET", "bus probe VER=%02X %02X %02X %02X %02X FLG=%02X -> %s", ver[0], ver[1], ver[2], ver[3], ver[4],
+          flg1,
+          verdict == Verdict::Uc8279Confirmed ? "UltraChip"
+          : verdict == Verdict::Uc8253Assumed ? "default controller"
+                                              : "inconclusive (default)");
+  if (mtpValid) {
+    char mtpHex[MTP_DUMP_LEN * 3 + 1];
+    for (size_t i = 0; i < MTP_DUMP_LEN; i++) {
+      snprintf(&mtpHex[i * 3], 4, " %02X", mtp[i]);
+    }
+    LOG_INF("XTDET", "MTP[0x000..0x02F]:%s", mtpHex);
+  }
+  return verdict;
+}
+
+}  // namespace X3EpdProbe
+
+bool detectX3DisplayIsUc8279() {
+  const NvsDeviceValue overrideValue = readNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
+  if (overrideValue != NvsDeviceValue::Unknown) {
+    LOG_INF("XTDET", "EPD controller override active: %s", overrideValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
+    return overrideValue == NvsDeviceValue::X3;
+  }
+
+  const NvsDeviceValue cachedValue = readNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
+  if (cachedValue != NvsDeviceValue::Unknown) {
+    LOG_INF("XTDET", "Using cached EPD controller: %s", cachedValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
+    return cachedValue == NvsDeviceValue::X3;
+  }
+
+  // The OEM records the panel controller in NVS hw_calib/screenType, but a
+  // full-flash from another unit can overwrite it — log it for diagnostics,
+  // never decide on it. The live bus probe is the ground truth.
+  {
+    Preferences prefs;
+    if (prefs.begin("hw_calib", true)) {
+      if (prefs.isKey("screenType")) {
+        LOG_INF("XTDET", "NVS hw_calib/screenType=%u [info only]", prefs.getUChar("screenType", 0));
+      } else {
+        LOG_INF("XTDET", "NVS hw_calib/screenType: not set [info only]");
+      }
+      prefs.end();
+    } else {
+      LOG_INF("XTDET", "NVS hw_calib/screenType: not set [info only]");
+    }
+  }
+
+  const X3EpdProbe::Verdict verdict = X3EpdProbe::probeController();
+  if (verdict == X3EpdProbe::Verdict::Uc8279Confirmed) {
+    LOG_INF("XTDET", "promoted UC8253 -> UC8279");
+    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::X3);
+    return true;
+  }
+  if (verdict == X3EpdProbe::Verdict::Uc8253Assumed) {
+    // Cache the negative too, or every cold boot on a UC8253 unit pays the
+    // full ~150 ms escalated probe.
+    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::X4);
+  }
+  // Inconclusive: run as UC8253 (the shipping controller) but don't persist,
+  // so a flaky first boot gets re-probed.
+  return false;
+}
+
 }  // namespace
 
 void HalGPIO::begin() {
   inputMgr.begin();
-  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
+  // Device fingerprint is I2C-only, so it can run before SPI comes up. The
+  // panel-controller probe bit-bangs the EPD pins, so it MUST run before
+  // SPI.begin() attaches them to the SPI matrix.
   _deviceType = detectDeviceTypeWithFingerprint();
+  _x3DisplayIsUc8279 = deviceIsX3() && detectX3DisplayIsUc8279();
+
+  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
   if (deviceIsX4()) {
     pinMode(BAT_GPIO0, INPUT);
     pinMode(UART0_RXD, INPUT);
+  }
+}
+
+void HalGPIO::toggleX3DisplayControllerOverride() {
+  const NvsDeviceValue current = readNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
+  if (current == NvsDeviceValue::X4) {
+    // Force-UC8253 already active: back to auto, drop the cache so the next
+    // boot re-probes. The in-RAM flag stays false for this boot (SPI already
+    // owns the EPD pins, re-probing now is unsafe).
+    writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
+    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
+    LOG_INF("XTDET", "EPD override cleared -> auto-detect on next boot");
+  } else {
+    writeNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::X4);
+    _x3DisplayIsUc8279 = false;
+    LOG_INF("XTDET", "EPD override set -> force UC8253");
   }
 }
 

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -66,13 +66,19 @@ class HalGPIO {
   // an NVS cache and a manual override (see NVS keys epd_det / epd_ovr).
   inline bool x3DisplayIsUc8279() const { return _x3DisplayIsUc8279; }
 
-  // Rescue hatch for a misdetected panel controller (Issue #109): toggles the
-  // EPD override in NVS. If no override is active, forces UC8253 (and drops
-  // the in-RAM UC8279 flag immediately, so a display init that follows in
-  // this same boot already uses the UC8253 driver). If the force-UC8253
-  // override is already active, clears it back to auto and drops the cache so
-  // the next boot re-probes. Wired to POWER + side-lower held at boot.
-  void toggleX3DisplayControllerOverride();
+  // Rescue hatch for a misdetected panel controller (Issue #109): cycles the
+  // EPD override in NVS through auto -> force UC8253 -> force UC8279 -> auto.
+  // Forced states update the in-RAM flag immediately (display init follows in
+  // the same boot); auto takes effect on the next boot (cache is dropped so
+  // it re-probes). Wired to POWER + side-lower long-held at boot. Returns the
+  // state that is now active, for on-screen feedback.
+  enum class EpdOverride : uint8_t { Auto = 0, ForceUc8253 = 1, ForceUc8279 = 2 };
+  EpdOverride toggleX3DisplayControllerOverride();
+
+  // Replay the panel-controller detection diagnostics (probe VER/FLG bytes,
+  // MTP dump, decision source) to the log. Call after Serial.begin() — the
+  // detection itself runs in begin(), before serial is up.
+  void logX3DisplayProbeDiag() const;
 
   // Start button GPIO and setup SPI for screen and SD card
   void begin();

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -51,6 +51,7 @@ class HalGPIO {
 
  private:
   DeviceType _deviceType = DeviceType::X4;
+  bool _x3DisplayIsUc8279 = false;
 
  public:
   HalGPIO() = default;
@@ -58,6 +59,20 @@ class HalGPIO {
   // Inline device type helpers for cleaner downstream checks
   inline bool deviceIsX3() const { return _deviceType == DeviceType::X3; }
   inline bool deviceIsX4() const { return _deviceType == DeviceType::X4; }
+
+  // True when the X3's panel controller was fingerprinted as the UC8279d
+  // sibling (newer production units). Always false on X4. Decided in begin()
+  // by a bit-banged bus probe on the EPD pins (before SPI claims them), with
+  // an NVS cache and a manual override (see NVS keys epd_det / epd_ovr).
+  inline bool x3DisplayIsUc8279() const { return _x3DisplayIsUc8279; }
+
+  // Rescue hatch for a misdetected panel controller (Issue #109): toggles the
+  // EPD override in NVS. If no override is active, forces UC8253 (and drops
+  // the in-RAM UC8279 flag immediately, so a display init that follows in
+  // this same boot already uses the UC8253 driver). If the force-UC8253
+  // override is already active, clears it back to auto and drops the cache so
+  // the next boot re-probes. Wired to POWER + side-lower held at boot.
+  void toggleX3DisplayControllerOverride();
 
   // Start button GPIO and setup SPI for screen and SD card
   void begin();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -412,6 +412,15 @@ void setup() {
       recoveryFirmwareMode = true;
       LOG_INF("MAIN", "Recovery firmware mode (side-upper + POWER held at boot)");
     }
+
+    // EPD コントローラ誤検出からの救済 (Issue #109): X3 で電源+側面下ボタンの
+    // 同時押しで UC8253 強制オーバーライドをトグルする。UC8253 機が UC8279 と
+    // 誤判定されると画面が映らず設定 UI に到達できないため、ボタンのみで
+    // 復旧できる経路を用意する。表示初期化 (setupDisplayAndFonts) より前に
+    // 実行されるので、このブートから即座に効く。
+    if (gpio.deviceIsX3() && gpio.isPressed(HalGPIO::BTN_DOWN)) {
+      gpio.toggleX3DisplayControllerOverride();
+    }
   }
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,6 +303,46 @@ static void resetSpiPins() {
   }
 }
 
+// EPDコントローラ・オーバーライドのトグルコンボ判定 (Issue #109)。
+// X3で電源+側面下ボタンを1.5秒以上長押しした場合のみ発火する。側面下は
+// 読書中の「次ページ」ボタンで電源投入時に触れている可能性が高いため、
+// 誤爆防止に長押しを必須とする。settleMs > 0 の場合は isPressed() が安定
+// するまで先に update() をポンプする（既に整定済みの呼び出し元は 0 を渡す）。
+// 発火した場合、トグル後の状態を表すメッセージを *msgOut に書いて true を返す。
+static bool checkEpdOverrideCombo(uint16_t settleMs, const char** msgOut) {
+  if (!gpio.deviceIsX3()) {
+    return false;
+  }
+  const unsigned long settleStart = millis();
+  while (millis() - settleStart < settleMs) {
+    gpio.update();
+    delay(10);
+  }
+  if (!gpio.isPressed(HalGPIO::BTN_DOWN)) {
+    return false;
+  }
+  const unsigned long holdStart = millis();
+  while (gpio.isPressed(HalGPIO::BTN_DOWN)) {
+    if (millis() - holdStart >= 1500) {
+      switch (gpio.toggleX3DisplayControllerOverride()) {
+        case HalGPIO::EpdOverride::ForceUc8253:
+          *msgOut = "EPD override: UC8253 forced";
+          break;
+        case HalGPIO::EpdOverride::ForceUc8279:
+          *msgOut = "EPD override: UC8279 forced";
+          break;
+        default:
+          *msgOut = "EPD override: auto (re-probe on next boot)";
+          break;
+      }
+      return true;
+    }
+    gpio.update();
+    delay(10);
+  }
+  return false;
+}
+
 void setup() {
   t1 = millis();
 
@@ -335,6 +375,9 @@ void setup() {
 #endif
 
   LOG_INF("MAIN", "Hardware detect: %s", gpio.deviceIsX3() ? "X3" : "X4");
+  // パネルコントローラ判別の診断リプレイ: 判別自体は gpio.begin() (Serial
+  // 初期化前) で走るため、ここで VER/FLG/MTP ダンプをシリアルに再出力する。
+  gpio.logX3DisplayProbeDiag();
 
   // SD Card Initialization
   // We need 6 open files concurrently when parsing a new chapter
@@ -351,8 +394,16 @@ void setup() {
   esp_task_wdt_deinit();
   if (!sdOk) {
     LOG_ERR("MAIN", "SD card initialization failed");
+    // SD不良とEPDコントローラ誤検出が重なった端末でも救済できるよう、この
+    // 早期returnパスでもオーバーライドコンボを判定する（通常パスの判定には
+    // 到達しないため）。ここはまだ整定していないので500msポンプする。
+    const char* epdOverrideMsg = nullptr;
+    if (gpio.getWakeupReason() == HalGPIO::WakeupReason::PowerButton) {
+      checkEpdOverrideCombo(500, &epdOverrideMsg);
+    }
     setupDisplayAndFonts();
-    activityManager.goToFullScreenMessage("SD card error", EpdFontFamily::BOLD);
+    activityManager.goToFullScreenMessage(epdOverrideMsg != nullptr ? epdOverrideMsg : "SD card error",
+                                          EpdFontFamily::BOLD);
     return;
   }
 
@@ -400,6 +451,7 @@ void setup() {
   // ボタン位置: X3 は BTN_UP が物理的に上側面上、X4 は BTN_DOWN が
   // 物理的に上側面上（MappedInputManager.cpp:14-23 参照）。
   bool recoveryFirmwareMode = false;
+  const char* epdOverrideMsg = nullptr;
   if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
     // isPressed() needs ~half a second to settle after boot.
     const unsigned long settleStart = millis();
@@ -414,19 +466,24 @@ void setup() {
     }
 
     // EPD コントローラ誤検出からの救済 (Issue #109): X3 で電源+側面下ボタンの
-    // 同時押しで UC8253 強制オーバーライドをトグルする。UC8253 機が UC8279 と
-    // 誤判定されると画面が映らず設定 UI に到達できないため、ボタンのみで
-    // 復旧できる経路を用意する。表示初期化 (setupDisplayAndFonts) より前に
-    // 実行されるので、このブートから即座に効く。
-    if (gpio.deviceIsX3() && gpio.isPressed(HalGPIO::BTN_DOWN)) {
-      gpio.toggleX3DisplayControllerOverride();
-    }
+    // 長押しでオーバーライドをトグルする（auto → UC8253強制 → UC8279強制 →
+    // auto）。誤検出されると画面が映らず設定 UI に到達できないため、ボタン
+    // のみで復旧できる経路を用意する。表示初期化 (setupDisplayAndFonts) より
+    // 前に実行されるので、強制状態はこのブートから即座に効く。
+    checkEpdOverrideCombo(0, &epdOverrideMsg);
   }
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);
 
   setupDisplayAndFonts();
+
+  // EPD オーバーライドをトグルした場合は結果を画面に表示して止める（誤爆でも
+  // 気づけるようにするため）。電源ボタンで再起動すると通常起動に戻る。
+  if (epdOverrideMsg != nullptr) {
+    activityManager.goToFullScreenMessage(epdOverrideMsg, EpdFontFamily::BOLD);
+    return;
+  }
 
 #ifdef GRAYSCALE_TEST_MODE
   activityManager.replaceActivity(std::make_unique<GrayscaleTestActivity>(renderer, mappedInputManager));


### PR DESCRIPTION
Closes #109

## 概要

新しい生産ロットのXteink X3はパネルコントローラがUC8253からUC8279dに変更されており（基板・ガラス・ピン配置は同一）、従来のUC8253専用ドライバでは画面が更新されませんでした。本家CrossPoint v1.5.0のfreeink-sdk実装（`Uc8279Driver` / `XteinkDetect`）を、本フォークの`open-x4-sdk`（community-sdk）のモノリシックな`EInkDisplay`と`lib/hal`に忠実移植しました。

UC8279dモジュールは**MTPがブランク**（Issue報告のMTPダンプでも確認）のため、初期化レジスタスクリプト（PSR/PWR/VDCS/BTST/PLL）と外部波形LUT一式をホストが供給する実装になっています。

## 変更内容

### 検出（lib/hal/HalGPIO）
- `SPI.begin()`より**前**に、EPDピンをビットバンする半二重SPIプローブでVER(0x70)/FLG(0x71)レジスタを読み、2パス一致でUC8279を確定（本家PR crosspoint-reader/crosspoint-reader#2707 と同方式）
- blank-MTP個体のフォールバック判定（RMTP 0xA2の先頭0xA5キー）も移植
- NVSキャッシュ`epd_det`・手動オーバーライド`epd_ovr`（本家と同一キー・同一値: 1=UC8253, 2=UC8279）。UC8253確定もキャッシュし、毎ブートのプローブ費用（約150ms）を回避
- `[XTDET]`ログは本家v1.5.0と同一形式（報告ログと突き合わせ可能）

### 誤検出時の救済経路
X3で起動時に**電源+側面下ボタン**同時押しでUC8253強制オーバーライドをトグル（再度実行でauto検出に戻る）。画面が映らない状態でもボタンだけで復旧できます。

### ドライバ（open-x4-sdk → zrn-ns/community-sdk feature/uc8279-x3）
- 初期化スクリプト再生（RST low 10ms）、全プレーン書き込み/リフレッシュを全画面PTLウィンドウ内で実行
- B/W: GC/DU差分リフレッシュ。**実際の旧フレーム(DTM1)との差分**で駆動（白シードは初回のみ。UC8253の毎回白ベースライン方式とは異なる）。CDIは1バイト（初回0x97→以降0xD7）
- 4階調グレースケール: XTF_AAバンク + AA-pre-BW(mid)前処理（E0/E5はAAパス限定）
- ダークモード: DU高速リフレッシュ時にDTM1を補数で書き直し、黒背景への残像蓄積を防止（`GfxRenderer::setDarkMode` → パネルドライバへ転送）
- deepSleep: 正規のDSLP(0x07+0xA5)

## 既知の挙動差・制限

- UC8279にはUC8253の`_half`(scrub)バンクに相当する中間段がなく、**HALFリフレッシュ（定期ゴースト除去）は毎回GCフラッシュ**になります（freeink実装と同一）
- LUT/CDI送出はUC8253パスと同じ単一CSフレーミング（freeinkは2パルス。実機で差が出た場合の調整ポイントとしてコード内に明記済み）
- UC8253のdeepSleep既存シーケンスは変更していません（別課題）

## 検証

- [x] `pio run`（default/gh_release）クリーンビルドでエラー・警告ゼロ
- [x] `bin/clang-format-fix`通過
- [x] Opus 5による設計レビュー（重大4件・推奨6件を反映済み: deepSleep分岐位置、BWパスの全画面PTL再設定、救済経路、RSTタイミング等）
- [ ] UC8253搭載X3実機でのリグレッションなし確認（プローブが`default controller`と判定し従来動作すること）
- [ ] UC8279搭載X3実機での表示確認（Issue #109 報告者に依頼予定: 起動時XTDETログ、ホーム/リーダー表示、ページ送り、グレースケールカバー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
