### PR TITLE
fix: 起動しないファームから自動でロールバックする

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -163,6 +163,10 @@ extra_scripts =
 ; Without this, every mbedTLS option in custom_sdkconfig below is compiled and
 ; then silently discarded — see the script's header.
   pre:scripts/patch_espidf_libcopy.py
+; verifyRollbackLater() の override がリンクで勝っているかをビルド後に検証する。
+; 失敗しても無言で「OTAロールバックが効かない」状態になるだけなので、
+; ビルドを落として気付けるようにしている。
+  post:scripts/check_rollback_hook.py
 
 ; Libraries
 lib_deps =

--- a/scripts/check_rollback_hook.py
+++ b/scripts/check_rollback_hook.py
@@ -11,12 +11,27 @@ with a bad OTA and watching it not recover.
 
 So check the linked ELF: the symbol must resolve to a strong definition ('T'),
 not to the core's weak fallback ('W').
+
+Two things make this survive a clean build. With custom_sdkconfig, PlatformIO
+links firmware.elf twice — once to bootstrap ESP-IDF, before src/ is compiled at
+all, and once for real. The check therefore hangs off firmware.bin, which is
+only produced from the final link, and additionally refuses to judge an ELF that
+does not contain setup() (i.e. one the sketch was never linked into).
 """
 
 import subprocess
 import sys
 
 SYMBOL = 'verifyRollbackLater'
+# From src/main.cpp, in a different translation unit than the override. Present
+# in the real firmware, absent from the bootstrap link (src/ is compiled after
+# it). setup()/loop() are no use here: they get inlined into loopTask.
+# Matched as a substring so the C++ mangling (name length prefix, signature)
+# does not have to be spelled out here.
+APP_MARKER = 'setupDisplayAndFonts'
+# Mangled fragment of the ota_rollback namespace. Used only to tell a genuine
+# bootstrap link apart from a stale APP_MARKER.
+MODULE_MARKER = '12ota_rollback'
 
 
 def fail(msg):
@@ -35,7 +50,7 @@ def find_nm(env):
 
 
 def check_rollback_hook(source, target, env):
-    elf = str(target[0])
+    elf = env.subst('$BUILD_DIR/${PROGNAME}.elf')
     nm = find_nm(env)
     if not nm:
         fail(f'could not derive nm from CC={env.subst("$CC")!r}')
@@ -47,11 +62,26 @@ def check_rollback_hook(source, target, env):
     except subprocess.CalledProcessError as e:
         fail(f'nm failed on {elf}: {e.stderr.strip()}')
 
-    matches = [
-        line.split()
-        for line in out.splitlines()
-        if line.split()[-1:] == [SYMBOL]
-    ]
+    symbols = [line.split() for line in out.splitlines() if line.split()]
+
+    names = [parts[-1] for parts in symbols]
+
+    # The bootstrap link contains framework code only. Judging it would fail
+    # every clean build, because the override cannot be there yet.
+    if not any(APP_MARKER in name for name in names):
+        # ...but do not take that on faith. If the module's own symbols are
+        # here, this is the real firmware and APP_MARKER simply went stale —
+        # say so rather than skipping the check for good.
+        if any(MODULE_MARKER in name for name in names):
+            fail(
+                f'{APP_MARKER} is missing from {elf} but {MODULE_MARKER} symbols are '
+                f'present, so this IS the application link. Update APP_MARKER in '
+                f'this script to a symbol src/main.cpp still exports.'
+            )
+        print(f'OTA rollback hook: {elf} is the ESP-IDF bootstrap link, skipping')
+        return
+
+    matches = [parts for parts in symbols if parts[-1] == SYMBOL]
     if not matches:
         fail(
             f'{SYMBOL} not present in {elf}. The OTA rollback deferral is not '
@@ -74,8 +104,11 @@ def check_rollback_hook(source, target, env):
 # PlatformIO/SCons entry point.
 try:
     Import('env')  # noqa: F821  # type: ignore[name-defined]
+    # Hooked on the .bin, not the .elf: with custom_sdkconfig the ELF is linked
+    # once before src/ is even compiled, and that bootstrap link has no override
+    # in it. The .bin only ever comes from the final link.
     env.AddPostAction(  # noqa: F821  # type: ignore[name-defined]
-        '$BUILD_DIR/${PROGNAME}.elf',
+        '$BUILD_DIR/${PROGNAME}.bin',
         # VerboseAction keeps SCons from echoing the whole object-file list.
         env.VerboseAction(  # noqa: F821  # type: ignore[name-defined]
             check_rollback_hook, 'Checking the OTA rollback hook'

--- a/scripts/check_rollback_hook.py
+++ b/scripts/check_rollback_hook.py
@@ -1,0 +1,85 @@
+"""
+PlatformIO post-build check: the verifyRollbackLater() override must win the link.
+
+src/OtaRollback.cpp overrides a weak symbol that the Arduino core defines in C
+(cores/esp32/esp32-hal-misc.c) and declares in no header. Drop the `extern "C"`,
+move the definition somewhere --gc-sections can discard, or let the file fall out
+of the build, and the link still succeeds — but initArduino() goes back to
+cancelling the rollback at boot, which is the exact bug src/OtaRollback.cpp
+exists to fix. Nothing about that failure is visible short of bricking a device
+with a bad OTA and watching it not recover.
+
+So check the linked ELF: the symbol must resolve to a strong definition ('T'),
+not to the core's weak fallback ('W').
+"""
+
+import subprocess
+import sys
+
+SYMBOL = 'verifyRollbackLater'
+
+
+def fail(msg):
+    print(f'ERROR [check_rollback_hook.py]: {msg}', file=sys.stderr)
+    sys.exit(1)
+
+
+def find_nm(env):
+    # The toolchain prefix comes from the compiler PlatformIO resolved for this
+    # board, so this keeps working if the target architecture ever changes.
+    cc = env.subst('$CC')
+    for suffix in ('-gcc', '-clang', '-cc'):
+        if cc.endswith(suffix):
+            return cc[: -len(suffix)] + '-nm'
+    return None
+
+
+def check_rollback_hook(source, target, env):
+    elf = str(target[0])
+    nm = find_nm(env)
+    if not nm:
+        fail(f'could not derive nm from CC={env.subst("$CC")!r}')
+
+    try:
+        out = subprocess.check_output([nm, elf], text=True, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        fail(f'{nm} not found; cannot verify the {SYMBOL}() override')
+    except subprocess.CalledProcessError as e:
+        fail(f'nm failed on {elf}: {e.stderr.strip()}')
+
+    matches = [
+        line.split()
+        for line in out.splitlines()
+        if line.split()[-1:] == [SYMBOL]
+    ]
+    if not matches:
+        fail(
+            f'{SYMBOL} not present in {elf}. The OTA rollback deferral is not '
+            f'linked in — automatic recovery from an unbootable firmware is off.'
+        )
+
+    # nm prints "<addr> <type> <name>"; an undefined symbol has no address.
+    types = {parts[-2] for parts in matches}
+    if 'T' not in types and 't' not in types:
+        fail(
+            f'{SYMBOL} resolved as {sorted(types)}, not a strong definition. '
+            f'The Arduino core\'s weak fallback won the link, so initArduino() '
+            f'still cancels the rollback at boot. Check that '
+            f'src/OtaRollback.cpp defines it inside `extern "C"`.'
+        )
+
+    print(f'OTA rollback hook: {SYMBOL} overridden by the project (ok)')
+
+
+# PlatformIO/SCons entry point.
+try:
+    Import('env')  # noqa: F821  # type: ignore[name-defined]
+    env.AddPostAction(  # noqa: F821  # type: ignore[name-defined]
+        '$BUILD_DIR/${PROGNAME}.elf',
+        # VerboseAction keeps SCons from echoing the whole object-file list.
+        env.VerboseAction(  # noqa: F821  # type: ignore[name-defined]
+            check_rollback_hook, 'Checking the OTA rollback hook'
+        ),
+    )
+except NameError:
+    print('check_rollback_hook.py is a PlatformIO post-build script; nothing to do.')

--- a/src/OtaRollback.cpp
+++ b/src/OtaRollback.cpp
@@ -1,0 +1,91 @@
+#include "OtaRollback.h"
+
+#include <Logging.h>
+#include <esp_ota_ops.h>
+
+// The Arduino core defines this weak, in C, in cores/esp32/esp32-hal-misc.c —
+// and declares it in no header at all. `extern "C"` is what makes this an
+// override rather than a separate C++-mangled function that nothing calls: get
+// it wrong and the build still succeeds while initArduino() goes on cancelling
+// the rollback at boot, exactly the bug this module exists to fix.
+//
+// scripts/check_rollback_hook.py fails the build if the linked symbol did not
+// come from here, so the mistake cannot be made silently.
+extern "C" bool verifyRollbackLater() { return true; }
+
+namespace ota_rollback {
+namespace {
+
+bool readState(const esp_partition_t* partition, esp_ota_img_states_t* state) {
+  return partition && esp_ota_get_state_partition(partition, state) == ESP_OK;
+}
+
+}  // namespace
+
+void markCurrentAppValid() {
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  esp_ota_img_states_t state;
+  if (!readState(running, &state)) {
+    LOG_ERR("BOOT", "Cannot read ota state; rollback confirmation skipped");
+    return;
+  }
+  // Anything else is already confirmed (or is a factory image). Writing again
+  // would erase and rewrite an otadata sector on every single boot.
+  if (state != ESP_OTA_IMG_PENDING_VERIFY) return;
+
+  const esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+  if (err != ESP_OK) {
+    LOG_ERR("BOOT", "Failed to confirm app: %s", esp_err_to_name(err));
+    return;
+  }
+  LOG_INF("BOOT", "App confirmed, rollback cancelled (%s)", running->label);
+}
+
+bool didRollBack() {
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  if (!running) return false;
+
+  // The slot the bootloader gave up on is the one it marked ABORTED. Scan the
+  // app partitions rather than assuming a two-slot layout.
+  esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+  bool aborted = false;
+  while (it) {
+    const esp_partition_t* part = esp_partition_get(it);
+    esp_ota_img_states_t state;
+    if (part != running && readState(part, &state) && state == ESP_OTA_IMG_ABORTED) {
+      aborted = true;
+      break;
+    }
+    it = esp_partition_next(it);
+  }
+  esp_partition_iterator_release(it);
+  return aborted;
+}
+
+const char* runningStateName() {
+  esp_ota_img_states_t state;
+  if (!readState(esp_ota_get_running_partition(), &state)) return "?";
+  switch (state) {
+    case ESP_OTA_IMG_NEW:
+      return "NEW";
+    case ESP_OTA_IMG_PENDING_VERIFY:
+      return "PENDING_VERIFY";
+    case ESP_OTA_IMG_VALID:
+      return "VALID";
+    case ESP_OTA_IMG_INVALID:
+      return "INVALID";
+    case ESP_OTA_IMG_ABORTED:
+      return "ABORTED";
+    case ESP_OTA_IMG_UNDEFINED:
+      return "UNDEFINED";
+    default:
+      return "?";
+  }
+}
+
+const char* runningPartitionLabel() {
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  return running ? running->label : "?";
+}
+
+}  // namespace ota_rollback

--- a/src/OtaRollback.cpp
+++ b/src/OtaRollback.cpp
@@ -20,7 +20,57 @@ bool readState(const esp_partition_t* partition, esp_ota_img_states_t* state) {
   return partition && esp_ota_get_state_partition(partition, state) == ESP_OK;
 }
 
+const char* stateName(esp_ota_img_states_t state) {
+  switch (state) {
+    case ESP_OTA_IMG_NEW:
+      return "NEW";
+    case ESP_OTA_IMG_PENDING_VERIFY:
+      return "PENDING_VERIFY";
+    case ESP_OTA_IMG_VALID:
+      return "VALID";
+    case ESP_OTA_IMG_INVALID:
+      return "INVALID";
+    case ESP_OTA_IMG_ABORTED:
+      return "ABORTED";
+    case ESP_OTA_IMG_UNDEFINED:
+      return "UNDEFINED";
+    default:
+      return "?";
+  }
+}
+
+// Some other slot was given up on by the bootloader, i.e. this boot is a
+// rollback. Scans the app partitions rather than assuming a two-slot layout.
+bool otherSlotAborted(const esp_partition_t* running) {
+  if (!running) return false;
+  esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+  bool aborted = false;
+  while (it) {
+    const esp_partition_t* part = esp_partition_get(it);
+    esp_ota_img_states_t state;
+    if (part != running && readState(part, &state) && state == ESP_OTA_IMG_ABORTED) {
+      aborted = true;
+      break;
+    }
+    it = esp_partition_next(it);
+  }
+  esp_partition_iterator_release(it);
+  return aborted;
+}
+
+const char* bootState = "?";
+bool rolledBack = false;
+
 }  // namespace
+
+void captureBootState() {
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  esp_ota_img_states_t state;
+  bootState = readState(running, &state) ? stateName(state) : "?";
+  rolledBack = otherSlotAborted(running);
+}
+
+const char* bootStateName() { return bootState; }
 
 void markCurrentAppValid() {
   const esp_partition_t* running = esp_ota_get_running_partition();
@@ -41,47 +91,7 @@ void markCurrentAppValid() {
   LOG_INF("BOOT", "App confirmed, rollback cancelled (%s)", running->label);
 }
 
-bool didRollBack() {
-  const esp_partition_t* running = esp_ota_get_running_partition();
-  if (!running) return false;
-
-  // The slot the bootloader gave up on is the one it marked ABORTED. Scan the
-  // app partitions rather than assuming a two-slot layout.
-  esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, nullptr);
-  bool aborted = false;
-  while (it) {
-    const esp_partition_t* part = esp_partition_get(it);
-    esp_ota_img_states_t state;
-    if (part != running && readState(part, &state) && state == ESP_OTA_IMG_ABORTED) {
-      aborted = true;
-      break;
-    }
-    it = esp_partition_next(it);
-  }
-  esp_partition_iterator_release(it);
-  return aborted;
-}
-
-const char* runningStateName() {
-  esp_ota_img_states_t state;
-  if (!readState(esp_ota_get_running_partition(), &state)) return "?";
-  switch (state) {
-    case ESP_OTA_IMG_NEW:
-      return "NEW";
-    case ESP_OTA_IMG_PENDING_VERIFY:
-      return "PENDING_VERIFY";
-    case ESP_OTA_IMG_VALID:
-      return "VALID";
-    case ESP_OTA_IMG_INVALID:
-      return "INVALID";
-    case ESP_OTA_IMG_ABORTED:
-      return "ABORTED";
-    case ESP_OTA_IMG_UNDEFINED:
-      return "UNDEFINED";
-    default:
-      return "?";
-  }
-}
+bool didRollBack() { return rolledBack; }
 
 const char* runningPartitionLabel() {
   const esp_partition_t* running = esp_ota_get_running_partition();

--- a/src/OtaRollback.h
+++ b/src/OtaRollback.h
@@ -19,6 +19,17 @@
 // before this module existed, not a regression.
 namespace ota_rollback {
 
+// Records the boot-time state, before markCurrentAppValid() overwrites it.
+// Call once, early in setup(). Without this there is no way to tell afterwards
+// whether the deferral worked: by the end of setup() the state reads VALID
+// either way, whether this build deferred the confirmation or the Arduino core
+// cancelled the rollback during initArduino().
+void captureBootState();
+
+// The state captured at boot ("PENDING_VERIFY" right after an update, "VALID"
+// on an ordinary boot). "?" before captureBootState() runs. Never null.
+const char* bootStateName();
+
 // Confirms the running app so the bootloader keeps it. Only writes when the app
 // is actually awaiting confirmation, so the common boot costs no flash write.
 // Safe to call more than once.
@@ -26,11 +37,8 @@ void markCurrentAppValid();
 
 // True when the previous boot failed to confirm itself and the bootloader fell
 // back to this app. Detected from the other slot being ESP_OTA_IMG_ABORTED.
+// Reflects what captureBootState() saw.
 bool didRollBack();
-
-// "NEW" / "PENDING_VERIFY" / "VALID" / "ABORTED" / "UNDEFINED" / "?" for the
-// running partition. For the boot diagnostics; never null.
-const char* runningStateName();
 
 // Label of the running app partition ("app0" / "app1"). Never null.
 const char* runningPartitionLabel();

--- a/src/OtaRollback.h
+++ b/src/OtaRollback.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Automatic recovery from a firmware that cannot boot.
+//
+// The bootloader supports it (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE) but the
+// Arduino core cancels it inside initArduino(), long before setup() runs — so a
+// build that dies while loading fonts or parsing app state used to be marked
+// good and stick, leaving an SD-card reflash as the only way out.
+//
+// This module defers that decision until setup() has finished. Reaching the end
+// of setup() means fonts loaded, settings and app state parsed, and an activity
+// started; anything that fails after that still leaves a device that boots and
+// draws. A build that dies earlier never records the confirmation, so the next
+// boot falls back to the previous app.
+//
+// Note this only helps when the other OTA slot holds a valid image. With an
+// empty slot the bootloader re-picks the aborted app (it scans for a loadable
+// image, not for the ota_state), which is a boot loop — the same behaviour as
+// before this module existed, not a regression.
+namespace ota_rollback {
+
+// Confirms the running app so the bootloader keeps it. Only writes when the app
+// is actually awaiting confirmation, so the common boot costs no flash write.
+// Safe to call more than once.
+void markCurrentAppValid();
+
+// True when the previous boot failed to confirm itself and the bootloader fell
+// back to this app. Detected from the other slot being ESP_OTA_IMG_ABORTED.
+bool didRollBack();
+
+// "NEW" / "PENDING_VERIFY" / "VALID" / "ABORTED" / "UNDEFINED" / "?" for the
+// running partition. For the boot diagnostics; never null.
+const char* runningStateName();
+
+// Label of the running app partition ("app0" / "app1"). Never null.
+const char* runningPartitionLabel();
+
+}  // namespace ota_rollback

--- a/src/activities/boot_sleep/BootActivity.cpp
+++ b/src/activities/boot_sleep/BootActivity.cpp
@@ -18,14 +18,17 @@ void BootActivity::onEnter() {
   renderer.drawImage(Logo120, (pageWidth - 120) / 2, (pageHeight - 120) / 2, 120, 120);
   renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2 + 70, tr(STR_CROSSPOINT), true, EpdFontFamily::BOLD);
   renderer.drawCenteredText(SMALL_FONT_ID, pageHeight / 2 + 95, tr(STR_BOOTING));
-  renderer.drawCenteredText(SMALL_FONT_ID, pageHeight - 30, CROSSPOINT_VERSION);
+  const int versionY = pageHeight - 30;
+  renderer.drawCenteredText(SMALL_FONT_ID, versionY, CROSSPOINT_VERSION);
   // 「設定 → 本体 → デバッグ表示」がONのときだけ、起動時の ota_state を出す。
   // OTA/SD更新の直後の初回起動が PENDING_VERIFY になっていれば、ロールバックの
   // 確認が setup() 完了まで遅延できている（src/OtaRollback.cpp 参照）。
+  //
+  // バージョン表記の下ではなく上に置く。画面下端は物理ベゼルに隠れて見切れる。
   if (SETTINGS.debugDisplay) {
     char buf[48];
     snprintf(buf, sizeof(buf), "ota=%s", ota_rollback::bootStateName());
-    renderer.drawCenteredText(SMALL_FONT_ID, pageHeight - 14, buf);
+    renderer.drawCenteredText(SMALL_FONT_ID, versionY - renderer.getLineHeight(SMALL_FONT_ID), buf);
   }
   renderer.displayBuffer();
 }

--- a/src/activities/boot_sleep/BootActivity.cpp
+++ b/src/activities/boot_sleep/BootActivity.cpp
@@ -3,6 +3,8 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
+#include "CrossPointSettings.h"
+#include "OtaRollback.h"
 #include "fontIds.h"
 #include "images/Logo120.h"
 
@@ -17,5 +19,13 @@ void BootActivity::onEnter() {
   renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2 + 70, tr(STR_CROSSPOINT), true, EpdFontFamily::BOLD);
   renderer.drawCenteredText(SMALL_FONT_ID, pageHeight / 2 + 95, tr(STR_BOOTING));
   renderer.drawCenteredText(SMALL_FONT_ID, pageHeight - 30, CROSSPOINT_VERSION);
+  // 「設定 → 本体 → デバッグ表示」がONのときだけ、起動時の ota_state を出す。
+  // OTA/SD更新の直後の初回起動が PENDING_VERIFY になっていれば、ロールバックの
+  // 確認が setup() 完了まで遅延できている（src/OtaRollback.cpp 参照）。
+  if (SETTINGS.debugDisplay) {
+    char buf[48];
+    snprintf(buf, sizeof(buf), "ota=%s", ota_rollback::bootStateName());
+    renderer.drawCenteredText(SMALL_FONT_ID, pageHeight - 14, buf);
+  }
   renderer.displayBuffer();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,10 +420,13 @@ void setup() {
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);
+  // markCurrentAppValid() より前に控えておく。setup() の最後で VALID にして
+  // しまうと、あとから「override が効いていたか」を確かめる術が無くなる。
   // OTA/SD更新の直後の初回起動なら PENDING_VERIFY になる。VALID しか出ないなら
   // verifyRollbackLater() の override が効いておらず、initArduino() が既に
   // 確認を済ませてしまっている（scripts/check_rollback_hook.py も参照）。
-  LOG_INF("BOOT", "Running %s, ota state %s", ota_rollback::runningPartitionLabel(), ota_rollback::runningStateName());
+  ota_rollback::captureBootState();
+  LOG_INF("BOOT", "Running %s, ota state %s", ota_rollback::runningPartitionLabel(), ota_rollback::bootStateName());
 
   setupDisplayAndFonts();
 
@@ -476,7 +479,13 @@ void setup() {
     appendPowerLog("RLBK ");
   }
 
-  appendPowerLog("WAKE ");
+  // 起動時の ota_state を残す。実機ではシリアルが取れないことが多く、SDカードを
+  // 抜いてこのログを読むのが一番確実な確認手段になる。
+  {
+    char wakeEvent[48];
+    snprintf(wakeEvent, sizeof(wakeEvent), "WAKE  ota=%s", ota_rollback::bootStateName());
+    appendPowerLog(wakeEvent);
+  }
 
   RECENT_BOOKS.loadFromFile();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include "MappedInputManager.h"
 #include "OpdsServerStore.h"
 #include "OrientationHelper.h"
+#include "OtaRollback.h"
 #include "RecentBooksStore.h"
 #include "SdCardFontSystem.h"
 #include "activities/Activity.h"
@@ -419,6 +420,10 @@ void setup() {
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);
+  // OTA/SD更新の直後の初回起動なら PENDING_VERIFY になる。VALID しか出ないなら
+  // verifyRollbackLater() の override が効いておらず、initArduino() が既に
+  // 確認を済ませてしまっている（scripts/check_rollback_hook.py も参照）。
+  LOG_INF("BOOT", "Running %s, ota state %s", ota_rollback::runningPartitionLabel(), ota_rollback::runningStateName());
 
   setupDisplayAndFonts();
 
@@ -463,6 +468,14 @@ void setup() {
     }
   }
 
+  // 前回の起動が自分自身の確認まで到達できず、ブートローダが旧アプリに戻した場合。
+  // ユーザーには「アップデートしたのにバージョンが戻っている」としか見えないので、
+  // 痕跡を残して後から追えるようにする。
+  if (ota_rollback::didRollBack()) {
+    LOG_INF("BOOT", "Previous boot did not confirm itself; rolled back to %s", ota_rollback::runningPartitionLabel());
+    appendPowerLog("RLBK ");
+  }
+
   appendPowerLog("WAKE ");
 
   RECENT_BOOKS.loadFromFile();
@@ -487,6 +500,12 @@ void setup() {
     APP_STATE.saveToFile();
     activityManager.goToReader(path);
   }
+
+  // ここまで来たら「このファームは起動できる」と確定してよい。フォント読み込み、
+  // 設定と APP_STATE のパース、アクティビティ生成を全て通過している。
+  // waitForPowerRelease() はボタンを離すまでブロックするので、その前に記録する。
+  // 押しっぱなしのまま電源を切られると確認が残らず、次回起動で戻ってしまう。
+  ota_rollback::markCurrentAppValid();
 
   // Ensure we're not still holding the power button before leaving setup
   waitForPowerRelease();


### PR DESCRIPTION
Closes #86

## 問題

ロールバック機能自体はブートローダ側で有効になっている。

```
CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
CONFIG_APP_ROLLBACK_ENABLE=y
```

しかし Arduino コアが `initArduino()` の中で `esp_ota_mark_app_valid_cancel_rollback()` を呼んで打ち消していた（`cores/esp32/esp32-hal-misc.c:312-318`）。

結果、**ロールバックが守るのは `initArduino()` 到達前のクラッシュだけ**で、`setup()` の中で死ぬファーム（フォント読み込みでのOOM、`APP_STATE` の新形式パース失敗など）は valid 扱いで焼き付き、SDカードからの手動フラッシュでしか復旧できなかった。X3 は USB フラッシュがロックされうるため文鎮化のリスクがある。

## 対処

コアが用意している weak フック `verifyRollbackLater()` を override して、確認を `setup()` の完了まで遅らせる。

`setup()` の最後まで到達していれば、フォント読み込み・設定と `APP_STATE` のパース・アクティビティ生成を全て通過している。それ以降に落ちても端末は起動して画面を出せるので、焼き付いて構わない。

| 判断 | 理由 |
|---|---|
| 書き込みは `PENDING_VERIFY` のときだけ | 毎回呼ぶと otadata セクタの消去・書き込みが起動ごとに発生する |
| `waitForPowerRelease()` の**前**に記録 | あれはボタンを離すまでブロックする。押しっぱなしで電源を切られると確認が残らず、次回起動で戻ってしまう |
| リカバリモードでも記録 | ロールバックの役目は「起動できない」ファームからの復帰であって「気に入らない」ファームからの復帰ではない。除外すると、誤ってリカバリモードに入って何もせず再起動しただけで旧ファームに戻る |

## `extern "C"` 忘れをビルドで止める

`verifyRollbackLater` は C ファイルに weak 定義があるだけで、**どのヘッダにも宣言が無い**。C++ から override するには `extern "C"` が必須で、付け忘れると名前修飾が付いて override にならない。**ビルドは通り、起動時のキャンセルもそのまま残る**ので、失敗が一切表に出ない。

`scripts/check_rollback_hook.py` を post ビルドで走らせ、`nm` でシンボル型を検査する。実際に `extern "C"` を外して検証済み。

```
ERROR [check_rollback_hook.py]: verifyRollbackLater resolved as ['W'], not a strong
definition. The Arduino core's weak fallback won the link, so initArduino() still
cancels the rollback at boot.
*** [.pio/build/default/firmware.elf] Explicit exit, status 1
```

将来 override が別ファイルに移動しても `--gc-sections` に落とされても、ビルドが落ちて気付ける。

## 確認手段

`ota_state` は `setup()` の最後で `VALID` になるため、後から見ても「遅延できていた」のか「コアが起動時に確認を済ませていた」のか区別が付かない。起動直後の状態を控えて2箇所に出す。

- **ブート画面**: デバッグ表示ONのとき `ota=<状態>`
- **powerlog**: `WAKE  ota=<状態>`、ロールバック検出時は `RLBK`

実機はシリアルが切れて読めないことが多く、SDを抜いて `/.crosspoint/power_log.txt` を読むのが最も確実。

## 実機検証（X3、2026-08-22 — すべて PASS）

`setup()` 内で意図的にクラッシュするビルド（版を `0.0.99` にして判別可能にした）をSDから焼いて確認した。SD更新経路も `ota_state = ESP_OTA_IMG_NEW` を書くため、OTAを経由せずに検証できる。

**powerlog:**

```
19:35:05 WAKE  ota=PENDING_VERIFY   ← ok.bin を焼いた直後の初回起動
19:35:28 WAKE  ota=VALID            ← 2回目、確認済みになった
19:36:52 WAKE  ota=PENDING_VERIFY   ← ok.bin を焼き直し
         （crash.bin を焼く → 起動 → クラッシュ。WAKEログには到達しない）
19:38:27 RLBK                        ← ロールバックを検出
19:38:27 WAKE  ota=VALID            ← ok.bin に戻って起動
```

**crash_report.txt のクラッシュ直前のログ:**

```
[804] [DBG] [ACT] Entering activity: Boot
[812] [DBG] [GFX] Time = 8 ms from clearScreen to displayBuffer
```

ここで途切れている。意図的なクラッシュを仕込んだ場所そのもの。`crash.bin` は `appendPowerLog` にすら到達していないため自分の起動記録を残せていないが、次の起動で `RLBK` が記録されている ＝ ブートローダが自力で旧アプリに戻した。

- [x] override が効いている（焼いた直後が `PENDING_VERIFY`）
- [x] `markCurrentAppValid()` が呼ばれている（2回目以降が `VALID`）
- [x] 誤ロールバックしない（正常なファームで再起動を繰り返しても戻らない）
- [x] **起動しないファームから自動復帰する**（`RLBK` 記録 + 旧版での起動、2回とも成功）
- [x] `pio run`（default / gh_release）0 warning、`pio check` クリーン、clang-format 差分なし
- [x] nm チェックが通る（かつ `extern "C"` を外すと落ちることを確認済み）

## 既知の限界

- **ロールバック先のスロットが空/壊れている場合は助けにならない。** ブートローダは `ota_state` ではなくイメージの正当性だけを見て走査するため（`bootloader_utility.c:579-630`）、ABORTED にした新ファーム自身が前方走査で拾われて再度起動し、起動ループになる。**ただしこれは本変更の前と同じ状態であって悪化はしない**（文鎮化もしない）。SD更新はスロットを交互に使うので通常運用では両スロットが埋まっている
- **`setupDisplayAndFonts()` の中で落ちる場合はリカバリモードにも到達できない**（リカバリ画面の起動は `main.cpp:470`、フォント初期化は `:423`）。これは Issue #86 の対処案2（リカバリ分岐の前倒し）でしか塞げないため、別Issueに切り出す
- deep sleep からの復帰は速経路を通り `PENDING_VERIFY → ABORTED` の処理を行わない（同 `:518-548`）。ただしクラッシュはパニックリセットであり deep sleep 復帰ではないので、ロールバックの成立には影響しない
- 起動中に電源を切ると（更新直後の初回起動なら）ロールバックする。稀だが `RLBK` の記録で追える

## 関連

#114（OTAアップデートチャネル）は未検証ビルドを配る機能なので、起動しないファームを掴む確率が上がる。Issue #91 も本件を先に塞ぐことを推奨しており、**本PRを先にマージする想定**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)