### PR TITLE
fix: 隣接章がない方向への長押し章スキップを抑止する

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -394,17 +394,23 @@ void EpubReaderActivity::loop() {
   const bool skipChapter = SETTINGS.longPressChapterSkip && mappedInput.getHeldTime() > skipChapterMs;
 
   if (skipChapter) {
-    lastPageTurnTime = millis();
-    // We don't want to delete the section mid-render, so grab the semaphore
-    {
-      RenderLock lock(*this);
-      nextPageNumber = 0;
-      const bool skipForward = verticalMode ? !nextTriggered : nextTriggered;
-      currentSpineIndex = skipForward ? currentSpineIndex + 1 : currentSpineIndex - 1;
-      section.reset();
+    // 隣接する章が存在しない方向へのスキップは抑止し、通常のページめくりに落とす。
+    // 1章構成の書籍で誤って長押しすると、前方は末尾（読了マークが付き読書位置を失う）、
+    // 後方は書籍の先頭へ飛ばされてしまうため。
+    const bool skipForward = verticalMode ? !nextTriggered : nextTriggered;
+    const int targetSpineIndex = skipForward ? currentSpineIndex + 1 : currentSpineIndex - 1;
+    if (targetSpineIndex >= 0 && targetSpineIndex < epub->getSpineItemsCount()) {
+      lastPageTurnTime = millis();
+      // We don't want to delete the section mid-render, so grab the semaphore
+      {
+        RenderLock lock(*this);
+        nextPageNumber = 0;
+        currentSpineIndex = targetSpineIndex;
+        section.reset();
+      }
+      requestUpdate();
+      return;
     }
-    requestUpdate();
-    return;
   }
 
   // No current section, attempt to rerender the book


### PR DESCRIPTION
## 概要

Closes #113

1章構成の書籍で読書中に誤ってページめくりボタンを長押しすると、章スキップが発動して書籍の末尾・先頭に飛ばされてしまう問題を修正する。

## 背景

`SETTINGS.longPressChapterSkip`（設定 → 操作 → 「長押し章スキップ」）で機能全体のON/OFFは以前から切り替え可能だった。ただし OFF にするとページめくりの契機がリリース時 → プレス時に変わる副作用がある（`src/activities/reader/ReaderUtils.h:40`）ため、機能を有効にしたまま誤操作を防げるようにした。

特に前方への誤スキップは実害が大きい。1章構成の書籍で前方長押しすると `currentSpineIndex` が spine 数と一致し、`EpubReaderActivity.cpp:785-786` の `saveProgress(..., true)` によって**書籍が読了扱いになり、読書位置も失われる**。後方長押しは index が負値になり、クランプで書籍の先頭に飛ばされていた。

## 変更内容

`EpubReaderActivity::loop()` の章スキップ処理で、スキップ先の spine index が `[0, spine数)` の範囲外になる場合は章スキップを行わず、通常のページめくりとして扱うようにした。

- 1章構成の書籍: 前方・後方どちらの長押しも通常のページめくりになる
- 複数章の書籍: 最初の章での後方長押し、最後の章での前方長押しのみ抑止（章間の移動は従来どおり）
- 書籍末尾の "End of book" 画面へは、最終ページから通常のページめくりで従来どおり到達できる

XtcReaderActivity 側の長押しは「章スキップ」ではなく「10ページスキップ」であり、既に範囲クランプ済みで読了マークも付かないため対象外。

## 検証

- [x] `pio run` 成功（RAM 15.6% / Flash 92.6%、変化なし）
- [x] `bin/clang-format-fix` で差分なし
- [x] `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` → No defects found
- [x] 実機確認: 1章構成のEPUBで前方・後方長押しが通常のページめくりになること（読了マークが付かないこと）
- [x] 実機確認: 複数章のEPUBで章間の長押しスキップが従来どおり動作すること
- [x] 実機確認: 縦書きモードでもスキップ方向が正しいこと

実機にて `crosspoint-pr118.bin` をSDファームウェア更新で書き込み、上記3点を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
