### PR TITLE
fix: 側面ボタンの向きが直感に反する問題を修正 (#104)

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -5,22 +5,21 @@
 namespace {
 using ButtonIndex = uint8_t;
 
-struct SideLayoutMap {
-  ButtonIndex pageBack;
-  ButtonIndex pageForward;
+// 側面ボタンの物理的な並び。`first` が並びの先頭（画面上で前・手前方向）、
+// `second` が末尾（次方向）。ADC のチャンネル名と物理位置は一致しないので、
+// 生の HalGPIO::BTN_UP / BTN_DOWN をこの構造体の外で直接使ってはならない。
+//
+//   X4: 右端に縦2つ。first = 物理上 = BTN_DOWN(5)、second = 物理下 = BTN_UP(4)。
+//   X3: 左右の端に1つずつ。first = 左 = BTN_UP(4)、second = 右 = BTN_DOWN(5)。
+//
+// X3 側は実機で検証済み。X4 側は cjk-fork の b2c06f4c（on-device 検証と記載）と
+// Issue #104 の報告症状（NEXT_PREV 設定で物理上=次ページ）が一致する。
+struct SidePair {
+  ButtonIndex first;
+  ButtonIndex second;
 };
-
-// Order matches CrossPointSettings::SIDE_BUTTON_LAYOUT.
-// X4: BTN_DOWN(5) is physically UPPER, BTN_UP(4) is physically LOWER.
-// X3: BTN_UP(4) is physically UPPER, BTN_DOWN(5) is physically LOWER (normal).
-constexpr SideLayoutMap kSideLayoutsX4[] = {
-    {HalGPIO::BTN_DOWN, HalGPIO::BTN_UP},  // PREV_NEXT: top(DOWN)=prev, bottom(UP)=next
-    {HalGPIO::BTN_UP, HalGPIO::BTN_DOWN},  // NEXT_PREV
-};
-constexpr SideLayoutMap kSideLayoutsX3[] = {
-    {HalGPIO::BTN_UP, HalGPIO::BTN_DOWN},  // PREV_NEXT: top(UP)=prev, bottom(DOWN)=next
-    {HalGPIO::BTN_DOWN, HalGPIO::BTN_UP},  // NEXT_PREV
-};
+constexpr SidePair kSideX4{HalGPIO::BTN_DOWN, HalGPIO::BTN_UP};
+constexpr SidePair kSideX3{HalGPIO::BTN_UP, HalGPIO::BTN_DOWN};
 
 // Mirror a front button hardware index (0<->3, 1<->2) for inverted orientation.
 // Physical buttons reverse left-to-right when the device is held upside down.
@@ -29,10 +28,27 @@ constexpr ButtonIndex mirrorFront(ButtonIndex idx) { return 3 - idx; }
 
 bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {
   const auto sideLayout = static_cast<CrossPointSettings::SIDE_BUTTON_LAYOUT>(SETTINGS.sideButtonLayout);
-  const auto& side = gpio.deviceIsX3() ? kSideLayoutsX3[sideLayout] : kSideLayoutsX4[sideLayout];
+  const bool isX3 = gpio.deviceIsX3();
+  const SidePair& sideHw = isX3 ? kSideX3 : kSideX4;
   const bool inverted = effectiveOrientation == Orientation::PortraitInverted;
   const bool landscapeCW = effectiveOrientation == Orientation::LandscapeClockwise;
   const bool landscapeCCW = effectiveOrientation == Orientation::LandscapeCounterClockwise;
+
+  // 画面から見た並び。上下反転時は物理位置が入れ替わる。
+  const ButtonIndex sideFirst = inverted ? sideHw.second : sideHw.first;
+  const ButtonIndex sideSecond = inverted ? sideHw.first : sideHw.second;
+
+  // 値の増減方向。X3 は横並びなので「右＝増」、X4 は縦並びなので「上＝増」。
+  // リストのカーソル移動は両機種とも「先頭側＝前の項目」で一致するので、
+  // 増減だけが X3 で Up/Down と逆向きになる。
+  const ButtonIndex sideIncrease = isX3 ? sideSecond : sideFirst;
+  const ButtonIndex sideDecrease = isX3 ? sideFirst : sideSecond;
+
+  // ページ送りだけは読書方向の好み（sideButtonLayout）で極性を反転できる。
+  // ここは反転前の物理インデックスを使い、向き補正は case 側でまとめて行う。
+  const bool prevNext = sideLayout == CrossPointSettings::PREV_NEXT;
+  const ButtonIndex pageBackHw = prevNext ? sideHw.first : sideHw.second;
+  const ButtonIndex pageForwardHw = prevNext ? sideHw.second : sideHw.first;
 
   switch (button) {
     case Button::Back:
@@ -54,11 +70,14 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       if (landscapeCCW) return (gpio.*fn)(SETTINGS.frontButtonLeft);
       return (gpio.*fn)(SETTINGS.frontButtonRight);
     case Button::Up:
-      // Side buttons remain fixed for Up/Down.
-      // Inverted: swap physical Up/Down.
-      return (gpio.*fn)(inverted ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP);
+      // 側面ボタンの並びの先頭側。リストでは「前の項目」に相当する。
+      return (gpio.*fn)(sideFirst);
     case Button::Down:
-      return (gpio.*fn)(inverted ? HalGPIO::BTN_UP : HalGPIO::BTN_DOWN);
+      return (gpio.*fn)(sideSecond);
+    case Button::ValueIncrease:
+      return (gpio.*fn)(sideIncrease);
+    case Button::ValueDecrease:
+      return (gpio.*fn)(sideDecrease);
     case Button::Power:
       // Power button bypasses remapping.
       return (gpio.*fn)(HalGPIO::BTN_POWER);
@@ -66,11 +85,11 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       // Reader page navigation uses side buttons and can be swapped via settings.
       // Inverted: side buttons swap physical position.
       // CW: side buttons move to bottom, Down(left)/Up(right), swap needed.
-      if (inverted || landscapeCW) return (gpio.*fn)(side.pageForward);
-      return (gpio.*fn)(side.pageBack);
+      if (inverted || landscapeCW) return (gpio.*fn)(pageForwardHw);
+      return (gpio.*fn)(pageBackHw);
     case Button::PageForward:
-      if (inverted || landscapeCW) return (gpio.*fn)(side.pageBack);
-      return (gpio.*fn)(side.pageForward);
+      if (inverted || landscapeCW) return (gpio.*fn)(pageBackHw);
+      return (gpio.*fn)(pageForwardHw);
   }
 
   return false;

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -4,7 +4,23 @@
 
 class MappedInputManager {
  public:
-  enum class Button { Back, Confirm, Left, Right, Up, Down, Power, PageBack, PageForward };
+  // Up/Down は「側面ボタンの並びの先頭側／末尾側」を指す論理ボタン。
+  // X4 は縦2つ並びなので上／下、X3 は左右1つずつなので左／右に対応する。
+  // ValueIncrease/ValueDecrease はスライダー等の値増減用。並びが縦か横かで
+  // 「増える側」が変わる（縦なら上、横なら右）ため Up/Down とは別に持つ。
+  enum class Button {
+    Back,
+    Confirm,
+    Left,
+    Right,
+    Up,
+    Down,
+    ValueIncrease,
+    ValueDecrease,
+    Power,
+    PageBack,
+    PageForward
+  };
   enum class Orientation { Portrait, PortraitInverted, LandscapeClockwise, LandscapeCounterClockwise };
 
   struct Labels {

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
@@ -51,8 +51,10 @@ void EpubReaderPercentSelectionActivity::loop() {
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Left}, [this] { adjustPercent(-kSmallStep); });
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Right}, [this] { adjustPercent(kSmallStep); });
 
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this] { adjustPercent(kLargeStep); });
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down}, [this] { adjustPercent(-kLargeStep); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::ValueIncrease},
+                                       [this] { adjustPercent(kLargeStep); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::ValueDecrease},
+                                       [this] { adjustPercent(-kLargeStep); });
 }
 
 void EpubReaderPercentSelectionActivity::render(RenderLock&&) {

--- a/src/activities/settings/AozoraActivity.cpp
+++ b/src/activities/settings/AozoraActivity.cpp
@@ -840,22 +840,28 @@ void AozoraActivity::loop() {
       return;
     }
 
-    buttonNavigator_.onNextRelease([this] {
+    // カーソル移動は前面ボタン（↑/↓）のみに割り当てる。側面ボタンはページ送り
+    // 専用なので、ButtonNavigator の onNext/onPrevious（側面 Up/Down を含む）は
+    // ここでは使えない。使うと1回の押下でカーソル移動とページ取得が同時に走り、
+    // ページ取得側が selectedIndex_ を 0 に戻すためカーソル移動が消える。#104
+    buttonNavigator_.onRelease({MappedInputManager::Button::Right}, [this] {
       if (selectedIndex_ < static_cast<int>(works_.size()) - 1) {
         selectedIndex_++;
         requestUpdate();
       }
     });
 
-    buttonNavigator_.onPreviousRelease([this] {
+    buttonNavigator_.onRelease({MappedInputManager::Button::Left}, [this] {
       if (selectedIndex_ > 0) {
         selectedIndex_--;
         requestUpdate();
       }
     });
 
-    // ページ送り（右ボタン=次ページ、左ボタン=前ページ）
-    if (mappedInput.wasPressed(MappedInputManager::Button::PageForward)) {
+    // ページ送りは側面ボタンの物理的な並び順に従う（先頭側=前ページ、末尾側=次
+    // ページ）。この一覧は横書きなので、読書方向の設定（sideButtonLayout）では
+    // なく画面の向きに合わせる。X4 なら上=前/下=次、X3 なら左=前/右=次。
+    if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
       if (worksOffset_ + WORKS_PAGE_SIZE < worksTotal_) {
         worksOffset_ += WORKS_PAGE_SIZE;
         {
@@ -875,7 +881,7 @@ void AozoraActivity::loop() {
       }
     }
 
-    if (mappedInput.wasPressed(MappedInputManager::Button::PageBack)) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
       if (worksOffset_ > 0) {
         worksOffset_ = (worksOffset_ >= WORKS_PAGE_SIZE) ? worksOffset_ - WORKS_PAGE_SIZE : 0;
         {

--- a/src/activities/settings/LineSpacingSelectionActivity.cpp
+++ b/src/activities/settings/LineSpacingSelectionActivity.cpp
@@ -52,8 +52,10 @@ void LineSpacingSelectionActivity::loop() {
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Left}, [this] { adjustValue(-kSmallStep); });
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Right}, [this] { adjustValue(kSmallStep); });
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this] { adjustValue(kLargeStep); });
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down}, [this] { adjustValue(-kLargeStep); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::ValueIncrease},
+                                       [this] { adjustValue(kLargeStep); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::ValueDecrease},
+                                       [this] { adjustValue(-kLargeStep); });
 }
 
 void LineSpacingSelectionActivity::render(RenderLock&&) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -397,12 +397,12 @@ void setup() {
       break;
   }
 
-  // Recovery firmware mode: 起動時に電源+左側面上ボタンの同時押しで
+  // Recovery firmware mode: 起動時に電源+側面ボタン（並びの先頭側）の同時押しで
   // SD カード経由のファーム更新画面へ直行する。USB フラッシュがロック
   // された端末（特に X3）で他 FW へ戻すための救済経路。
   //
-  // ボタン位置: X3 は BTN_UP が物理的に上側面上、X4 は BTN_DOWN が
-  // 物理的に上側面上（MappedInputManager.cpp:14-23 参照）。
+  // ボタン位置: 側面ボタンの並びの先頭側を使う。X3 は左側面の BTN_UP、
+  // X4 は右側面の上側（BTN_DOWN）。MappedInputManager.cpp の SidePair 参照。
   bool recoveryFirmwareMode = false;
   if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
     // isPressed() needs ~half a second to settle after boot.
@@ -414,7 +414,7 @@ void setup() {
     const uint8_t recoveryButton = gpio.deviceIsX3() ? HalGPIO::BTN_UP : HalGPIO::BTN_DOWN;
     if (gpio.isPressed(recoveryButton)) {
       recoveryFirmwareMode = true;
-      LOG_INF("MAIN", "Recovery firmware mode (side-upper + POWER held at boot)");
+      LOG_INF("MAIN", "Recovery firmware mode (side-first + POWER held at boot)");
     }
   }
 


### PR DESCRIPTION
## 背景

Issue #104 は「青空文庫の作品一覧で側面ボタンの移動方向が直感に反する」という報告だが、調べると原因は3層に分かれていた。

### 1. `Button::Up`/`Down` が機種別の物理配置テーブルを通っていなかった

`MappedInputManager` は「X4 は `BTN_DOWN` が物理的に上、X3 は左右に並んでいて `BTN_UP` が左」という物理配置を宣言していたが、この情報を使っていたのは `PageBack`/`PageForward` だけで、`Button::Up`/`Down`（リスト送り・スライダー全般）は生の `BTN_UP`/`BTN_DOWN` に直結していた。

結果、同じ物理ボタンに対して2つの論理ボタンが逆の意味を持つ状態になっていた。X4 では「物理的に下のボタンを押すとリストのカーソルが上に動く」ことになる。

### 2. 値の増減方向が機種の物理配置と噛み合わない

側面ボタンが縦2つ並びの X4 では「上＝増える」が自然だが、左右1つずつの X3 では「右＝増える」が自然。1つの `Button::Up` にはこの両方を割り当てられないため、行間（1.00x）と移動先% のスライダーは X3 で「左を押すと値が増える」状態だった（実機で確認）。

### 3. 作品一覧が側面ボタンを二重にバインドしていた

`AozoraActivity` の `WORK_LIST` では、`ButtonNavigator::onNext/onPrevious`（側面 Up/Down を含む）とページ送りの `PageForward`/`PageBack` が**同じ物理ボタン**に割り当たっていた。1回の押下でカーソル移動とページ取得が同時に発火し、ページ取得側が `selectedIndex_` を 0 に戻すためカーソル移動が見えず、リスト先頭でも突然ページが飛ぶ挙動になっていた。これが報告された症状そのもの。

## 変更内容

**1. 側面ボタンの物理配置を単一の真実の情報源にした** (`MappedInputManager`)

`SidePair{first, second}`（並びの先頭側／末尾側）を定義し、`Up`/`Down`・`ValueIncrease`/`ValueDecrease`・`PageBack`/`PageForward` をすべてここから導出する。生の `BTN_UP`/`BTN_DOWN` を `switch` 内で直接使う箇所は無くなった。

- X4: `first` = 物理上 = `BTN_DOWN(5)`、`second` = 物理下 = `BTN_UP(4)`
- X3: `first` = 左 = `BTN_UP(4)`、`second` = 右 = `BTN_DOWN(5)`

`PageBack`/`PageForward` の結果は**従来と完全に同一**（読み替えのみ）。

**2. `Button::ValueIncrease` / `ValueDecrease` を追加**

行間と移動先% のスライダーで使用。X3 は右＝増、X4 は上＝増になる。

**3. 作品一覧の二重バインドを解消**

カーソル移動を前面ボタン（↑/↓、既存のヒント表示どおり）専用にし、ページ送りは側面ボタンの物理的な並び順に固定した。この一覧は横書きなので、読書方向の設定（`sideButtonLayout`）には追従させない。

- X4: 上＝前ページ / 下＝次ページ
- X3: 左＝前ページ / 右＝次ページ

報告者の希望（「下側で次ページ、上側で前ページ」「右側で次ページ、左側で前ページ」）と一致する。

## 挙動の変化まとめ

| 画面 | X3 | X4 |
|---|---|---|
| リストのカーソル移動（設定/Wi-Fi/フォント/キーボード等） | 変化なし（左＝前のまま） | **反転**（物理上＝前になる。従来は物理下＝前） |
| 行間・移動先% のスライダー | **反転**（右＝増になる） | **反転**（物理上＝増になる） |
| リーダーのページ送り | 変化なし | 変化なし |
| 青空文庫 作品一覧 | 側面＝ページ送り専用、左＝前/右＝次 | 側面＝ページ送り専用、上＝前/下＝次 |
| リカバリモードの起動ボタン | 変化なし（左側面） | 変化なし（右側面の上） |

## 検証

- `pio run`（default 環境）成功、警告なし。RAM 15.6% / Flash 92.6% で変化なし（`constexpr` テーブルのみ）
- `bin/clang-format-fix` 後 `git diff` 空（CI と同じ clang-format 21）
- 実機確認: **未実施**

## 実機確認のお願い

- [ ] **X3**: 行間スライダーで右側面ボタンを押すと数値が**増える**
- [ ] **X3**: 移動先% で右側面ボタンを押すと % が**増える**
- [ ] **X3**: 設定一覧・Wi-Fi 一覧のカーソル移動が従来どおり（左＝上へ）
- [ ] **X3**: リーダーのページ送りが従来どおり（設定を変えていないこと）
- [ ] **X3**: 青空文庫→作家から探す→作品一覧で、前面 ↑/↓ でカーソルが1件ずつ動き、左右側面でページが切り替わる
- [ ] **X3**: 上下反転表示でも上記が破綻しない
- [ ] **X3**: 横向き（LandscapeCW/CCW）で読書したあとホームに戻り、リストのカーソル移動が壊れていない
- [ ] **X4**: リスト・スライダー・作品一覧（報告者による確認が必要）

X4 の物理配置（`BTN_DOWN` が物理上）は実機未検証で、リポジトリ内の宣言と cjk-fork の記述、および Issue #104 の報告症状（`sideButtonLayout = NEXT_PREV` 前提）の一致から採用している。もし逆だった場合の修正は `kSideX4` の1行だけで済む。

Refs #104（実機確認が済むまでクローズしない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
