### PR TITLE
fix: 段落の最終行（縦書きは最終列）でルビが消える問題を修正

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -174,12 +174,14 @@ void ParsedText::setRubyForWordAt(size_t index, const std::string& ruby) {
 // rubyTexts は setRubyForWordAt() 時点の words.size() までしか伸びないため、
 // その後 addWord() された語の分は短い。範囲全体を一括判定すると
 // 末尾に語が追加された最終行（縦書きは最終列）だけルビが全て落ちるので、
-// 存在する分だけコピーし残りは空文字列で埋める。
-std::vector<std::string> ParsedText::copyRubyRange(const size_t start, const size_t end) const {
+// 存在する分だけ取り出し残りは空文字列で埋める。
+// 取り出した範囲は呼び出し側が直後に erase するので、words と同様にムーブで済ませる
+// （SSO を超えるルビ文字列のコピーによる malloc/free を避ける）。
+std::vector<std::string> ParsedText::takeRubyRange(const size_t start, const size_t end) {
   std::vector<std::string> out(end - start);
   if (rubyTexts.size() > start) {
     const size_t avail = std::min(rubyTexts.size(), end) - start;
-    std::copy(rubyTexts.begin() + start, rubyTexts.begin() + start + avail, out.begin());
+    std::move(rubyTexts.begin() + start, rubyTexts.begin() + start + avail, out.begin());
   }
   return out;
 }
@@ -393,7 +395,7 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
     std::vector<int16_t> colXpos;
     std::vector<EpdFontFamily::Style> colStyles(wordStyles.begin() + start, wordStyles.begin() + end);
     const size_t count = end - start;
-    std::vector<std::string> colRubyTexts = copyRubyRange(start, end);
+    std::vector<std::string> colRubyTexts = takeRubyRange(start, end);
     colYpos.reserve(count);
     colXpos.resize(count, 0);
 
@@ -728,7 +730,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
-  std::vector<std::string> lineRubyTexts = copyRubyRange(lastBreakAt, lineBreak);
+  std::vector<std::string> lineRubyTexts = takeRubyRange(lastBreakAt, lineBreak);
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -170,6 +170,20 @@ void ParsedText::setRubyForWordAt(size_t index, const std::string& ruby) {
   rubyTexts[index] = ruby;
 }
 
+// [start, end) の語に対応するルビを取り出す。
+// rubyTexts は setRubyForWordAt() 時点の words.size() までしか伸びないため、
+// その後 addWord() された語の分は短い。範囲全体を一括判定すると
+// 末尾に語が追加された最終行（縦書きは最終列）だけルビが全て落ちるので、
+// 存在する分だけコピーし残りは空文字列で埋める。
+std::vector<std::string> ParsedText::copyRubyRange(const size_t start, const size_t end) const {
+  std::vector<std::string> out(end - start);
+  if (rubyTexts.size() > start) {
+    const size_t avail = std::min(rubyTexts.size(), end) - start;
+    std::copy(rubyTexts.begin() + start, rubyTexts.begin() + start + avail, out.begin());
+  }
+  return out;
+}
+
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
                                        const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
@@ -379,12 +393,7 @@ void ParsedText::layoutVerticalColumns(const GfxRenderer& renderer, const int fo
     std::vector<int16_t> colXpos;
     std::vector<EpdFontFamily::Style> colStyles(wordStyles.begin() + start, wordStyles.begin() + end);
     const size_t count = end - start;
-    std::vector<std::string> colRubyTexts;
-    if (rubyTexts.size() >= end) {
-      colRubyTexts.assign(rubyTexts.begin() + start, rubyTexts.begin() + end);
-    } else {
-      colRubyTexts.resize(count);
-    }
+    std::vector<std::string> colRubyTexts = copyRubyRange(start, end);
     colYpos.reserve(count);
     colXpos.resize(count, 0);
 
@@ -719,12 +728,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
-  std::vector<std::string> lineRubyTexts;
-  if (rubyTexts.size() >= lineBreak) {
-    lineRubyTexts.assign(rubyTexts.begin() + lastBreakAt, rubyTexts.begin() + lineBreak);
-  } else {
-    lineRubyTexts.resize(lineWordCount);
-  }
+  std::vector<std::string> lineRubyTexts = copyRubyRange(lastBreakAt, lineBreak);
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -39,6 +39,7 @@ class ParsedText {
                    const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
                    int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
+  std::vector<std::string> copyRubyRange(size_t start, size_t end) const;
 
  public:
   explicit ParsedText(const bool hyphenationEnabled = false, const BlockStyle& blockStyle = BlockStyle(),

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -39,7 +39,7 @@ class ParsedText {
                    const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
                    int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
-  std::vector<std::string> copyRubyRange(size_t start, size_t end) const;
+  std::vector<std::string> takeRubyRange(size_t start, size_t end);
 
  public:
   explicit ParsedText(const bool hyphenationEnabled = false, const BlockStyle& blockStyle = BlockStyle(),


### PR DESCRIPTION
## 概要

ルビ付きの段落で、最終行（縦書きでは最終列）のルビだけが全て消える問題を修正します。1 行で完結する段落は全ルビが消えていました。

## 原因

`ParsedText::rubyTexts` は `setRubyForWordAt()` を呼んだ時点の `words.size()` までしか伸びず、その後 `addWord()` された語の分だけ `words` より短くなります（正常な状態）。ところが `extractLine()`（横書き）と `layoutVerticalColumns()`（縦書き）は `rubyTexts.size() >= end` で行全体を一括判定していたため、末尾に語が追加された最終行だけ else に落ち、行内の全ルビが空文字列になっていました。

## 変更

- `ParsedText::takeRubyRange(start, end)` を追加。存在する範囲だけ取り出し、残りを空文字列で埋める
- 取り出した範囲は呼び出し側が直後に erase するため、`words` と同様にムーブで済ませ、SSO を超えるルビ文字列の malloc/free を削減（2 コミット目）
- vector のヒープ確保回数は従来（`assign` または `resize` の 1 回）と同じ

## 確認

- ホストシミュレータ（`scripts/sim_run.ts`、`test/epubs/ja_ruby.epub`、BIZUDGothic）で縦書き・横書きとも最終行のルビが表示されることを確認
- `pio run -e default` / `pio check --fail-on-defect low,medium,high` / clang-format が通る
- Fable によるレビュー済み（必須修正なし、ムーブ化の提案を反映）

## 前後比較（シミュレータ X4、BIZUDGothic、`test/epubs/ja_ruby.epub`）

縦書き: 第 1 段落（1 列で完結＝最終列）の `吾輩`・`猫`・`名前`・`無` と、第 2 段落最終列の `記憶` にルビが付く

| 修正前 | 修正後 |
|---|---|
| ![縦書き 修正前](https://github.com/user-attachments/assets/bbfccb99-17a1-46f1-a5cd-e4d76bfc199f) | ![縦書き 修正後](https://github.com/user-attachments/assets/cce6e20b-a523-4c46-a718-e7d172efd2c7) |

横書き: 各段落の最終行（`記憶`・`種族`・`話`）にルビが付く

| 修正前 | 修正後 |
|---|---|
| ![横書き 修正前](https://github.com/user-attachments/assets/8d83177f-247a-4d92-8b13-4db86ec9ead6) | ![横書き 修正後](https://github.com/user-attachments/assets/47d886ba-a576-47bc-9209-f3e9523c6ecb) |

## 実機で見てほしい点

- ルビ付き EPUB を開き、段落末（縦書きなら最終列）のルビが出ること。セクションキャッシュはレイアウト結果を含むため、既存のキャッシュ（`.crosspoint/epub_*/sections/`）を削除して再生成してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
