### PR TITLE
fix: アクティビティ遷移時に画面の向き設定を適用する (#120)

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -3,6 +3,7 @@
 #include <HalPowerManager.h>
 
 #include "OpdsServerStore.h"
+#include "OrientationHelper.h"
 #include "SdCardFontGlobals.h"
 #include "boot_sleep/BootActivity.h"
 #include "boot_sleep/SleepActivity.h"
@@ -87,6 +88,12 @@ void ActivityManager::loop() {
         currentActivity = std::move(stackActivities.back());
         stackActivities.pop_back();
         LOG_DBG("ACT", "Popped from activity stack, new size = %zu", stackActivities.size());
+
+        // 前面に戻るアクティビティの画面・入力の向きを適用する。各アクティビティは
+        // supportsLandscape() で「設定どおりの横向きを使う」か「Portrait/Inverted に留まる」かを
+        // 決めるので、Portrait の UI サブアクティビティから横向きのリーダーへ戻るときも
+        // ここで正しく回転する。
+        OrientationHelper::applyOrientation(renderer, mappedInput, currentActivity.get());
         // Handle result if necessary
         if (currentActivity->resultHandler) {
           LOG_DBG("ACT", "Handling result for popped activity");
@@ -127,6 +134,13 @@ void ActivityManager::loop() {
       pendingAction = PendingAction::None;
       currentActivity = std::move(pendingActivity);
 
+      // onEnter と初回描画が正しい向きを見るように、onEnter の前に画面・入力の向きを適用する。
+      // 横向きのリーダーから push された UI サブアクティビティは Portrait/Inverted になり、
+      // pop で戻るときに上の経路でリーダーの向きに戻る。
+      // RenderLock を保持したまま行う（適用は enum の代入だけでロックを取らない）。
+      // unlock 後に行うと、残っていた描画通知でレンダータスクが旧向きのまま 1 フレーム描き得る。
+      OrientationHelper::applyOrientation(renderer, mappedInput, currentActivity.get());
+
       lock.unlock();  // onEnter may acquire its own lock
       currentActivity->onEnter();
 
@@ -163,6 +177,8 @@ void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
   } else {
     // No current activity, safe to launch immediately
     currentActivity = std::move(newActivity);
+    // 起動直後（Boot）も含め、初回描画の前に向きを適用する
+    OrientationHelper::applyOrientation(renderer, mappedInput, currentActivity.get());
     currentActivity->onEnter();
   }
 }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -23,11 +23,14 @@
 void SleepActivity::onEnter() {
   Activity::onEnter();
 
-  // Show popup with reader orientation only when going to sleep from reader
+  // Show popup with reader orientation only when going to sleep from reader.
+  // ActivityManager は Sleep 進入時に UI の向き（Portrait/Inverted）を適用済みなので、
+  // ポップアップ後は Portrait 固定ではなくその向きに戻す（UI 反転時のスリープ画面のため）。
   if (APP_STATE.lastSleepFromReader) {
+    const auto uiOrientation = renderer.getOrientation();
     ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
     GUI.drawPopup(renderer, tr(STR_ENTERING_SLEEP));
-    renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+    renderer.setOrientation(uiOrientation);
   } else {
     GUI.drawPopup(renderer, tr(STR_ENTERING_SLEEP));
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -180,7 +180,7 @@ void EpubReaderActivity::onEnter() {
   // ルビフォントIDはrender()内でフォントロード後に設定
 
   // Screen orientation (both renderer and input) is already set by
-  // enterNewActivity() → OrientationHelper::applyOrientation() before onEnter().
+  // ActivityManager → OrientationHelper::applyOrientation() before onEnter().
 
   epub->setupCacheDir();
 
@@ -251,8 +251,9 @@ void EpubReaderActivity::onEnter() {
 void EpubReaderActivity::onExit() {
   Activity::onExit();
 
-  // Reset orientation back to portrait for the rest of the UI
-  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+  // 次のアクティビティの向き（renderer と入力の両方）は ActivityManager が
+  // Pop / Replace 時に OrientationHelper で適用するので、ここでは戻さない。
+  // renderer だけ Portrait に戻すと入力側の向きが残留する（#120）。
 
   APP_STATE.readerActivityLoadCount = 0;
   APP_STATE.saveToFile();

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -41,7 +41,6 @@ class KOReaderSyncActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool preventAutoSleep() override { return state == CONNECTING || state == SYNCING; }
-  bool supportsLandscape() const override { return true; }
   bool isReaderActivity() const override { return true; }
 
  private:

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -29,7 +29,8 @@ void TxtReaderActivity::onEnter() {
     return;
   }
 
-  ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
+  // Screen orientation (renderer + input) is applied by ActivityManager via
+  // OrientationHelper before onEnter(), so no explicit setOrientation here.
 
   txt->setupCacheDir();
 
@@ -47,8 +48,8 @@ void TxtReaderActivity::onEnter() {
 void TxtReaderActivity::onExit() {
   Activity::onExit();
 
-  // Reset orientation back to portrait for the rest of the UI
-  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+  // 次のアクティビティの向きは ActivityManager が Pop / Replace 時に適用するので、
+  // ここでは戻さない（EpubReaderActivity::onExit と同じ）。
 
   pageOffsets.clear();
   currentPageLines.clear();


### PR DESCRIPTION
## 概要

Issue #120 の修正です。画面の向き設定を実際に適用する `OrientationHelper::applyOrientation()` の呼び出しが通常のアクティビティ遷移経路から失われており、次の 3 件が同時に起きていました。

1. 設定 → 表示 → UI の向き = 反転 がまったく効かない
2. EPUB リーダーが起動直後は `SETTINGS.orientation`（横向き等）を無視して Portrait で描画する
3. リーダーで向きを変えると、リーダーを出たあとの UI にも入力側の向きが残る

## 変更

- `ActivityManager` の 3 つの遷移経路（Push/Replace の `onEnter` 直前、Pop で前面に戻るとき、起動直後の即時 Replace）で `applyOrientation()` を呼ぶ。各アクティビティは `supportsLandscape()` で「設定どおりの 4 方向」か「Portrait/Inverted」かを選ぶ。適用は RenderLock 保持中に行い、残っていた描画通知で旧向きのまま 1 フレーム描かれる窓を作らない
- `EpubReaderActivity` / `TxtReaderActivity` の `onEnter` での自前適用と、`onExit` での renderer だけの Portrait 戻し（入力側が残留する原因）を削除
- `KOReaderSyncActivity` は描画が Portrait 固定座標の UI 画面なので `supportsLandscape()` を外す
- `SleepActivity` はリーダーからのスリープ時にポップアップ後 Portrait 固定に戻していたが、UI 反転時にスリープ画面だけ Portrait になるので、適用済みの UI の向きに戻す

移植元は aBER0724/crosspoint-reader-cjk の同等実装（ac672adf / 47b838ff）です。

## 前後比較（シミュレータ X4）

シミュレータは論理座標で表示するため、UI 反転では文字は正立のまま、ボタンヒントが物理ボタン側（上）に移り、バッテリー表示が下に来ます。

**UI の向き = 反転 でホーム画面**

| 修正前（反転が効かない） | 修正後 |
|---|---|
| ![UI 反転 修正前](https://github.com/user-attachments/assets/e35265af-ef97-4898-a381-00c84c103d0e) | ![UI 反転 修正後](https://github.com/user-attachments/assets/0a286afe-fb63-441e-8772-94a1806f2e56) |

**読書方向 = 横向き時計回り の EPUB を起動直後に開く**

| 修正前（Portrait で描画） | 修正後（横向き） |
|---|---|
| ![リーダー 修正前](https://github.com/user-attachments/assets/b72ef944-bafc-4b4e-ae29-195c0644a5cc) | ![リーダー 修正後](https://github.com/user-attachments/assets/f3a2f1fe-9514-4eb8-99e6-aedbfaf68f1a) |

**リーダー → メニュー（Portrait）→ リーダーに戻る（横向きに復帰）**

| メニュー | 戻った直後 |
|---|---|
| ![リーダーメニュー](https://github.com/user-attachments/assets/1a9e971b-d37b-4de2-8e16-cec7c27a7aee) | ![リーダーに復帰](https://github.com/user-attachments/assets/1a9c0eff-f720-4fd1-932e-db3e404a1d40) |

## 確認

- `pio run -e default` / `pio check` / clang-format が通る
- Fable によるレビュー済み（必須修正なし。推奨 2 件＝ロック内での適用・SleepActivity を反映）

## 設計上の注記（要判断）

横向きリーダーから開くメニュー・目次・脚注などのサブアクティビティは Portrait/Inverted で描かれます（cjk-fork と同じ方針）。これらの画面には本家由来の横向き専用レイアウトコードが残っており、この PR 後は到達不能になります。「サブアクティビティにリーダーの向きを継承させる」か「後続でデッドコードを削除する」かは別途決めたいです。

## 実機で見てほしい点

- UI の向き = 反転 でホーム・設定・確認ダイアログが反転し、前面ボタンの役割が鏡像になること
- 読書方向を横向きにした本を、電源を切って再起動してから開いても横向きで表示されること
- リーダーを出たあとのホームで前面ボタンの割り当てが正しいこと（不具合 3）

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
