### PR TITLE
fix: 横書きで行頭のルビがビューポート外に出て欠ける問題を修正

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -5,7 +5,7 @@
 
 void PageLine::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset,
                       const int viewportWidth) {
-  block->render(renderer, fontId, xPos + xOffset, yPos + yOffset, viewportWidth);
+  block->render(renderer, fontId, xPos + xOffset, yPos + yOffset, viewportWidth, xOffset);
 }
 
 void PageLine::collectCodepoints(std::vector<uint32_t>& out, size_t max) const {

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -42,8 +42,8 @@ bool TextBlock::hasRuby() const {
   return false;
 }
 
-void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int x, const int y,
-                       const int viewportWidth) const {
+void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int x, const int y, const int viewportWidth,
+                       const int viewportX) const {
   // Validate iterator bounds before rendering
   if (words.size() != wordXpos.size() || words.size() != wordStyles.size()) {
     LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u)\n", (uint32_t)words.size(),
@@ -124,7 +124,15 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
       if (rubyFontId != 0 && i < rubyTexts.size() && !rubyTexts[i].empty()) {
         const int baseWidth = renderer.getTextAdvanceX(effectiveFontId, words[i].c_str(), currentStyle);
         const int rubyWidth = renderer.getTextWidth(rubyFontId, rubyTexts[i].c_str(), EpdFontFamily::REGULAR);
-        const int rubyX = wordXpos[i] + x + (baseWidth - rubyWidth) / 2;
+        // 親文字の中央に置く（中付き）。ルビが親文字より長いときは前後の文字にかぶせる
+        // （JLREQ の「ルビの突出」）が、行頭・行末ではビューポートの外に出て欠けるので、
+        // 行の範囲内に収まるように寄せる。
+        int rubyX = wordXpos[i] + x + (baseWidth - rubyWidth) / 2;
+        if (viewportWidth > 0) {
+          const int maxX = viewportX + viewportWidth - rubyWidth;
+          if (rubyX > maxX) rubyX = maxX;
+          if (rubyX < viewportX) rubyX = viewportX;
+        }
         const int rubyY = y - renderer.getLineHeight(rubyFontId) - 1;
         renderer.drawText(rubyFontId, rubyX, rubyY, rubyTexts[i].c_str(), true, EpdFontFamily::REGULAR);
       }

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -45,7 +45,10 @@ class TextBlock final : public Block {
   bool isEmpty() override { return words.empty(); }
   size_t wordCount() const { return words.size(); }
   // given a renderer works out where to break the words into lines
-  void render(const GfxRenderer& renderer, int fontId, int x, int y, int viewportWidth = 0) const;
+  // viewportX / viewportWidth はビューポート（余白を除いた描画領域）の左端 x と幅。
+  // 横書きルビの行頭・行末での突出をビューポート内に抑えるために使う。
+  // viewportWidth が 0 のときはクランプしない。
+  void render(const GfxRenderer& renderer, int fontId, int x, int y, int viewportWidth = 0, int viewportX = 0) const;
   void collectCodepoints(std::vector<uint32_t>& out, size_t max) const;
   BlockType getType() override { return TEXT_BLOCK; }
   bool serialize(FsFile& file) const;


### PR DESCRIPTION
## 概要

横書きで行頭の語のルビが左余白にはみ出し、画面端で欠ける問題を直します。ルビは親文字の中央に置く（中付き）ため、親文字より長いルビは前後に突出します。行頭ではその突出分がビューポートの外に出ていました（ja_ruby.epub の「ところ」「あく」「つかま」）。行末でも同様に右へ出うる状態でした。

## 変更

- `PageLine::render` からビューポート左端（余白）を `TextBlock::render` に渡し、横書きルビの x を [ビューポート左端, 右端 − ルビ幅] に収める
- 行中の突出（隣の文字にかぶる）は従来どおり許容。JLREQ 3.3.8 の「ルビ先頭を行頭に揃えて親文字を字下げ」は改行計算にルビ幅が必要でキャッシュ版数更新を伴うため、今回は描画側の補正に留める
- レイアウト結果（TextBlock のシリアライズ内容）は不変なので section.bin の版数は据え置き

## 前後比較（シミュレータ X4、BIZUDGothic、ja_ruby.epub 横書き）

行頭の「ところ」「あく」「つかま」のルビが左端で欠けなくなる

| 修正前 | 修正後 |
|---|---|
| ![行頭ルビ 修正前](https://github.com/user-attachments/assets/fca02399-c1ca-4f48-8703-9db89df1450f) | ![行頭ルビ 修正後](https://github.com/user-attachments/assets/24572ef5-9048-404e-b5f3-e6adc245cde7) |

## 確認

- `pio run -e default` / `pio check` / clang-format が通る
- Fable によるレビュー済み（必須修正なし。コミット文とコメントの表現を修正）

## 対象外（別 Issue 候補）

縦書きのルビ（列の右側）は既定の行間（185%）では列内に収まりますが、行間を 120% 以下に詰めると最右列で右余白を超え得ます。こちらはパーサ側で最右列にルビ分の溝を確保する対応が筋で、キャッシュ版数更新を伴うため別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
