### PR TITLE
fix: OTA の未初期化 memcpy と app 全域消去を解消

### DIFF
--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -69,7 +69,9 @@ void ReleaseJsonParser::commitAsset() {
   // dropped rather than truncated, which would otherwise mark the release
   // installable with an empty download URL.
   if (strcmp(currentAssetName, "firmware.bin") == 0 && currentAssetUrl[0] != '\0') {
-    memcpy(currentFwUrl, currentAssetUrl, sizeof(currentFwUrl));
+    // 両配列は同じ長さだが、NUL 終端以降の未初期化領域まで丸ごとコピーする
+    // のは未定義動作なので、文字列としての長さだけを写す (#88)。
+    safeCopy(currentFwUrl, sizeof(currentFwUrl), currentAssetUrl, strlen(currentAssetUrl));
     currentFwSize = currentAssetSize;
     currentFwFound = true;
   }

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -204,8 +204,13 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
     return INTERNAL_UPDATE_ERROR;
   }
 
+  // OTA_SIZE_UNKNOWN だと app パーティション全域 (約 6.8MB) を事前消去する。
+  // イメージサイズは checkForUpdate() でリリースのアセット情報から判明して
+  // いるので、それを渡して消去範囲を実サイズ分に絞る (#89)。消去中はフラッシュ
+  // キャッシュが止まるため、その時間が直接短くなる。サイズ不明なら従来どおり。
+  const size_t eraseSize = otaSize > 0 ? otaSize : static_cast<size_t>(OTA_SIZE_UNKNOWN);
   esp_ota_handle_t otaHandle = 0;
-  esp_err_t esp_err = esp_ota_begin(updatePartition, OTA_SIZE_UNKNOWN, &otaHandle);
+  esp_err_t esp_err = esp_ota_begin(updatePartition, eraseSize, &otaHandle);
   if (esp_err != ESP_OK) {
     LOG_ERR("OTA", "esp_ota_begin failed: %s", esp_err_to_name(esp_err));
     char buf[96];
@@ -229,6 +234,13 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   const bool fetchOk = HttpDownloader::fetchUrl(
       otaUrl,
       [&](const uint8_t* data, size_t len) {
+        // 消去済み領域は otaSize 分しかない。アセット情報より大きい本体が
+        // 流れてきたら未消去領域への書き込みになるので、その前に止める。
+        if (otaSize > 0 && processedSize + len > otaSize) {
+          writeErr = ESP_ERR_INVALID_SIZE;
+          flashOk = false;
+          return false;
+        }
         writeErr = esp_ota_write(otaHandle, data, len);
         if (writeErr != ESP_OK) {
           flashOk = false;


### PR DESCRIPTION
Closes #88, Closes #89

## 変更内容

- **#88** `ReleaseJsonParser::commitAsset()`: 512 バイト固定の `memcpy` を、同ファイルの `safeCopy()` に置き換え。NUL 終端以降の未初期化領域を読まない
- **#89** `OtaUpdater::installUpdate()`: `esp_ota_begin()` に `OTA_SIZE_UNKNOWN` ではなくリリースアセットの実サイズ (`otaSize`) を渡す。消去範囲が app パーティション全域 (約 6.8MB) から実サイズ分 (現状 約 6.3MB) に縮む。サイズ不明 (0) のときは従来どおり `OTA_SIZE_UNKNOWN`
- 消去済み領域を超える書き込みが来た場合は `esp_ota_write()` を呼ぶ前に中断する（アセット情報と本体サイズが食い違ったときに未消去領域へ書かない保険）

## 検証

- `pio run -e default` 成功、clang-format 差分なし
- **実機での OTA 更新は未確認。** マージ前に Dev チャネルで 1 回更新できることを確認したい（消去時間が短くなるのが体感できるはず）

## 重要度

#89 は OTA の書き込み経路に触るため、実機で更新が通ることを確認してからマージするのが安全です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)