### PR TITLE
ci: 再実行で中身の古い Dev Build が配信されるのを防ぐ

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -41,12 +41,35 @@ jobs:
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
+      # 再実行ガード (#117)。ワークフローを再実行すると GITHUB_SHA は元のコミット
+      # のまま、タイムスタンプだけが「今」になる。その間にリリースタグが切られて
+      # いると「タグ名は最新なのに中身は古い」Dev Build ができ、正式リリースに
+      # 乗っている端末が Dev チャネルで一度ダウングレードしてしまう。
+      # HEAD から到達できる最新のリリースタグより新しい v* タグが存在するなら、
+      # この HEAD の Dev Build は既に古いのでスキップする。
+      - name: Check for newer release tag
+        id: guard
+        run: |
+          reachable="$(git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD 2>/dev/null || true)"
+          newest="$(git tag --list 'v[0-9]*' | sort -V | tail -n1)"
+          echo "reachable=${reachable:-<none>} newest=${newest:-<none>}"
+          skip=false
+          if [ -n "${newest}" ] && [ "${newest}" != "${reachable}" ]; then
+            higher="$(printf '%s\n%s\n' "${reachable}" "${newest}" | sort -V | tail -n1)"
+            if [ "${higher}" = "${newest}" ]; then
+              skip=true
+              echo "::warning::HEAD より新しいリリースタグ ${newest} が存在するため Dev Build をスキップします (HEAD は ${reachable:-タグなし} 以降)"
+            fi
+          fi
+          echo "skip=${skip}" >> "$GITHUB_OUTPUT"
+
       # ビルドより前に実行する。TIMESTAMP はタグ名 (dev-<stamp>) と
       # ファームウェアに埋め込む CROSSPOINT_BUILD_TIME の両方の出所であり、
       # この2つがバイト単位で一致することが「端末が自分自身を更新候補と
       # みなさない」ための条件になっている (src/BuildInfo.h 参照)。
       - name: Generate release metadata
         id: meta
+        if: steps.guard.outputs.skip != 'true'
         run: |
           TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
           DISPLAY_TIME="$(date -u +'%Y-%m-%d %H:%M:%S')"
@@ -60,6 +83,7 @@ jobs:
           echo "commit_msg=${COMMIT_MSG}" >> "$GITHUB_OUTPUT"
 
       - name: Build CrossPoint
+        if: steps.guard.outputs.skip != 'true'
         env:
           CROSSPOINT_BUILD_TIME: ${{ steps.meta.outputs.build_time }}
         run: |
@@ -81,6 +105,7 @@ jobs:
           cp "${partitions}" partitions.bin
 
       - name: Create Release
+        if: steps.guard.outputs.skip != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.tag_name }}


### PR DESCRIPTION
Closes #117

## 変更内容

`dev-build.yml` にガードステップ「Check for newer release tag」を追加。HEAD から到達できる最新の `v*` タグ (`git describe --abbrev=0`) より新しい `v*` タグがリポジトリに存在する場合、警告を出してメタデータ生成・ビルド・Release 作成をスキップする。

判定は `sort -V` による版比較。Issue 案の `--no-merged` は使っていない。origin には HEAD から到達できない古いタグ (v0.1.0〜v0.1.5) が残っており、`--no-merged` だと常にスキップになるため。

## 検証

ガードのシェルロジックをローカルで origin のタグ一覧に対して確認:

| ケース | 結果 |
|---|---|
| 現在の master (到達 v0.2.0, 最新 v0.2.0) | 実行 |
| v0.2.1 が切られた後に古いコミットを再実行 | スキップ |
| 到達不能な古いタグ (v0.1.0) だけがある | 実行 |
| HEAD から v* に到達できない | スキップ（保守的） |

`.github/workflows/**` は `paths-ignore` なので、この PR のマージ自体では Dev Build は走らない。次に `src/` 等が変わる push で通常どおり動くことを確認すればよい。

## 注意

upstream のタグ (v1.5.0 など) を origin に push すると常にスキップになる。origin には自分のリリースタグだけを置く前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)