### PR TITLE
fix: リカバリモードの分岐をフォント初期化直後に前倒し

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,6 +435,20 @@ void setup() {
   return;
 #endif
 
+  if (recoveryFirmwareMode) {
+    // 表示とフォントが揃ったら即リカバリ画面へ (#116)。APP_STATE / RECENT_BOOKS の
+    // 読み込みや時刻復元はここより後ろにあり、壊れたファームはそこで落ちることが
+    // ある。救済経路がそれらに依存しないよう、通常起動の処理には一切入らない。
+    // フォント初期化そのものが落ちる場合はこの前倒しでも救えない（既知の限界）。
+    activityManager.replaceActivity(
+        std::make_unique<SdFirmwareUpdateActivity>(renderer, mappedInputManager, /*recoveryMode=*/true));
+    // 従来どおりリカバリ画面に到達した時点で確認済みにする。ここで確認しないと、
+    // 誤ってリカバリに入っただけの正常なファームが次回起動でロールバックされる。
+    ota_rollback::markCurrentAppValid();
+    waitForPowerRelease();
+    return;
+  }
+
   activityManager.goToBoot();
 
   APP_STATE.loadFromFile();
@@ -489,11 +503,7 @@ void setup() {
 
   RECENT_BOOKS.loadFromFile();
 
-  if (recoveryFirmwareMode) {
-    // Skip normal home/reader routing: jump straight into the SD firmware picker.
-    activityManager.replaceActivity(
-        std::make_unique<SdFirmwareUpdateActivity>(renderer, mappedInputManager, /*recoveryMode=*/true));
-  } else if (HalSystem::isRebootFromPanic()) {
+  if (HalSystem::isRebootFromPanic()) {
     // If we rebooted from a panic, go to crash report screen to show the panic info
     activityManager.goToCrashReport();
   } else if (APP_STATE.openEpubPath.empty() || !APP_STATE.lastSleepFromReader ||


### PR DESCRIPTION
Closes #116

## 変更内容

`main.cpp` の `setup()` で、リカバリモード（電源＋側面ボタン同時押し）の分岐を `setupDisplayAndFonts()` の直後に移動。`goToBoot()` / `APP_STATE.loadFromFile()` / 時刻復元 / `RECENT_BOOKS.loadFromFile()` を通らずに `SdFirmwareUpdateActivity` へ入る。

`ota_rollback::markCurrentAppValid()` はリカバリ画面到達時に従来どおり呼ぶ。ここで確認しないと、誤ってリカバリに入っただけの正常なファームが次回起動でロールバックされてしまうため。

## 救えないケース（Issue 記載の既知の限界）

`setupDisplayAndFonts()` 自体が落ちる場合は前倒しでも到達できない。そこまで踏み込むには最小フォントだけ読む経路が要るので、この PR ではやっていない。

## 検証

- `pio run -e default` 成功、clang-format 差分なし
- **実機未確認。** 起動時のボタン長押しはシミュレータで再現できない。マージ前に実機で電源＋側面ボタンでリカバリ画面に入れること、通常起動が変わっていないことを確認したい

🤖 Generated with [Claude Code](https://claude.com/claude-code)