### PR TITLE
feat: リーダー配下の画面を横向きに対応（メニュー・章一覧・脚注・%移動）

### DIFF
--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -14,13 +14,10 @@ int EpubReaderChapterSelectionActivity::getPageItems() const {
   constexpr int lineHeight = 30;
 
   const int screenHeight = renderer.getScreenHeight();
-  const auto orientation = renderer.getOrientation();
-  // In inverted portrait, the button hints are drawn near the logical top.
-  // Reserve vertical space so list items do not collide with the hints.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int startY = 60 + hintGutterHeight;
-  const int availableHeight = screenHeight - startY - lineHeight;
+  // ボタンヒントの占める辺（縦持ちは下端、反転は上端）を避けた高さで行数を決める
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int startY = 60 + insets.top;
+  const int availableHeight = screenHeight - startY - insets.bottom;
   // Clamp to at least one item to avoid division by zero and empty paging.
   return std::max(1, availableHeight / lineHeight);
 }
@@ -90,18 +87,11 @@ void EpubReaderChapterSelectionActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
   const auto pageWidth = renderer.getScreenWidth();
-  const auto orientation = renderer.getOrientation();
-  // Landscape orientation: reserve a horizontal gutter for button hints.
-  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
-  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  // Inverted portrait: reserve vertical space for hints at the top.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
-  // Landscape CW places hints on the left edge; CCW keeps them on the right.
-  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
-  const int contentWidth = pageWidth - hintGutterWidth;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int contentY = hintGutterHeight;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = pageWidth - insets.left - insets.right;
+  const int contentY = insets.top;
   const int pageItems = getPageItems();
   const int totalItems = getTotalItems();
 

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.h
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.h
@@ -33,4 +33,6 @@ class EpubReaderChapterSelectionActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
 };

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -53,18 +53,11 @@ void EpubReaderFootnotesActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
   const auto pageWidth = renderer.getScreenWidth();
-  const auto orientation = renderer.getOrientation();
-  // Landscape orientation: reserve a horizontal gutter for button hints.
-  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
-  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  // Inverted portrait: reserve vertical space for hints at the top.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
-  // Landscape CW places hints on the left edge; CCW keeps them on the right.
-  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
-  const int contentWidth = pageWidth - hintGutterWidth;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int contentY = hintGutterHeight;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = pageWidth - insets.left - insets.right;
+  const int contentY = insets.top;
 
   // Manual centering to honor content gutters.
   const int titleX =
@@ -80,19 +73,21 @@ void EpubReaderFootnotesActivity::render(RenderLock&&) {
   }
 
   constexpr int lineHeight = 36;
-  const int screenWidth = renderer.getScreenWidth();
+  constexpr int listTop = 60;
   const int marginLeft = contentX + 20;
 
-  const int visibleCount = std::max(1, (renderer.getScreenHeight() - contentY) / lineHeight);
+  // 見出しとヒント領域を除いた高さに収まる行数だけ描く
+  const int visibleCount = std::max(1, (renderer.getScreenHeight() - listTop - contentY - insets.bottom) / lineHeight);
   if (selectedIndex < scrollOffset) scrollOffset = selectedIndex;
   if (selectedIndex >= scrollOffset + visibleCount) scrollOffset = selectedIndex - visibleCount + 1;
 
   for (int i = scrollOffset; i < static_cast<int>(footnotes.size()) && i < scrollOffset + visibleCount; i++) {
-    const int y = 60 + contentY + (i - scrollOffset) * lineHeight;
+    const int y = listTop + contentY + (i - scrollOffset) * lineHeight;
     const bool isSelected = (i == selectedIndex);
 
     if (isSelected) {
-      renderer.fillRect(0, y, screenWidth, lineHeight, true);
+      // ヒント領域には重ねない
+      renderer.fillRect(contentX, y, contentWidth, lineHeight, true);
     }
 
     // Show footnote number and abbreviated href

--- a/src/activities/reader/EpubReaderFootnotesActivity.h
+++ b/src/activities/reader/EpubReaderFootnotesActivity.h
@@ -20,6 +20,8 @@ class EpubReaderFootnotesActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
 
  private:
   const std::vector<FootnoteEntry>& footnotes;

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalGPIO.h>
 #include <I18n.h>
 
+#include <algorithm>
 #include <cstdio>
 
 #include "CrossPointSettings.h"
@@ -120,20 +121,11 @@ void EpubReaderMenuActivity::loop() {
 void EpubReaderMenuActivity::render(RenderLock&&) {
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
-  const auto orientation = renderer.getOrientation();
-  // Landscape orientation: button hints are drawn along a vertical edge, so we
-  // reserve a horizontal gutter to prevent overlap with menu content.
-  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
-  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  // Inverted portrait: button hints appear near the logical top, so we reserve
-  // vertical space to keep the header and list clear.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
-  // Landscape CW places hints on the left edge; CCW keeps them on the right.
-  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
-  const int contentWidth = pageWidth - hintGutterWidth;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int contentY = hintGutterHeight;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = pageWidth - insets.left - insets.right;
+  const int contentY = insets.top;
 
   // Title
   const std::string truncTitle =
@@ -155,10 +147,16 @@ void EpubReaderMenuActivity::render(RenderLock&&) {
   // Menu Items
   const int startY = 75 + contentY;
   constexpr int lineHeight = 30;
+  // 横向き（高さ 480）では全項目が収まらないので、選択項目を含むページだけを描く。
+  // 縦持ちでは全項目が 1 ページに入り、従来と同じ見え方になる。
+  const int availableHeight = renderer.getScreenHeight() - startY - insets.bottom;
+  const int pageItems = std::max(1, availableHeight / lineHeight);
+  const int pageStart = selectedIndex / pageItems * pageItems;
+  const int pageEnd = std::min(static_cast<int>(menuItems.size()), pageStart + pageItems);
 
-  for (size_t i = 0; i < menuItems.size(); ++i) {
-    const int displayY = startY + (i * lineHeight);
-    const bool isSelected = (static_cast<int>(i) == selectedIndex);
+  for (int i = pageStart; i < pageEnd; ++i) {
+    const int displayY = startY + ((i - pageStart) * lineHeight);
+    const bool isSelected = (i == selectedIndex);
 
     if (isSelected) {
       // Highlight only the content area so we don't paint over hint gutters.

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -40,6 +40,8 @@ class EpubReaderMenuActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
 
  private:
   struct MenuItem {

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
@@ -60,21 +60,28 @@ void EpubReaderPercentSelectionActivity::loop() {
 void EpubReaderPercentSelectionActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
-  const auto metrics = UITheme::getInstance().getMetrics();
-  const bool isPortraitInverted = renderer.getOrientation() == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterHeight = isPortraitInverted ? (metrics.buttonHintsHeight + metrics.verticalSpacing) : 0;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = renderer.getScreenWidth() - insets.left - insets.right;
+  const int hintGutterHeight = insets.top;
+
+  // 中央揃えはヒント領域を除いたコンテンツ幅に対して行う
+  auto drawCentered = [&](const int fontId, const int y, const char* text, const EpdFontFamily::Style style) {
+    const int x = contentX + (contentWidth - renderer.getTextWidth(fontId, text, style)) / 2;
+    renderer.drawText(fontId, x, y, text, true, style);
+  };
 
   // Title and numeric percent value.
-  renderer.drawCenteredText(UI_12_FONT_ID, 15 + hintGutterHeight, tr(STR_GO_TO_PERCENT), true, EpdFontFamily::BOLD);
+  drawCentered(UI_12_FONT_ID, 15 + hintGutterHeight, tr(STR_GO_TO_PERCENT), EpdFontFamily::BOLD);
 
   const std::string percentText = std::to_string(percent) + "%";
-  renderer.drawCenteredText(UI_12_FONT_ID, 90 + hintGutterHeight, percentText.c_str(), true, EpdFontFamily::BOLD);
+  drawCentered(UI_12_FONT_ID, 90 + hintGutterHeight, percentText.c_str(), EpdFontFamily::BOLD);
 
   // Draw slider track.
-  const int screenWidth = renderer.getScreenWidth();
   constexpr int barWidth = 360;
   constexpr int barHeight = 16;
-  const int barX = (screenWidth - barWidth) / 2;
+  const int barX = contentX + (contentWidth - barWidth) / 2;
   const int barY = 140 + hintGutterHeight;
 
   renderer.drawRect(barX, barY, barWidth, barHeight);
@@ -90,7 +97,7 @@ void EpubReaderPercentSelectionActivity::render(RenderLock&&) {
   renderer.fillRect(knobX, barY - 4, 4, barHeight + 8, true);
 
   // Hint text for step sizes.
-  renderer.drawCenteredText(SMALL_FONT_ID, barY + 30, tr(STR_PERCENT_STEP_HINT), true);
+  drawCentered(SMALL_FONT_ID, barY + 30, tr(STR_PERCENT_STEP_HINT), EpdFontFamily::REGULAR);
 
   // Button hints follow the current front button layout.
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), "-", "+");

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.h
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.h
@@ -16,6 +16,8 @@ class EpubReaderPercentSelectionActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
 
  private:
   // Current percent value (0-100) shown on the slider.

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
@@ -13,13 +13,10 @@ int XtcReaderChapterSelectionActivity::getPageItems() const {
   constexpr int lineHeight = 30;
 
   const int screenHeight = renderer.getScreenHeight();
-  const auto orientation = renderer.getOrientation();
-  // In inverted portrait, the hint row is drawn near the logical top.
-  // Reserve vertical space so the list starts below the hints.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int startY = 60 + hintGutterHeight;
-  const int availableHeight = screenHeight - startY - lineHeight;
+  // ボタンヒントの占める辺（縦持ちは下端、反転は上端）を避けた高さで行数を決める
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int startY = 60 + insets.top;
+  const int availableHeight = screenHeight - startY - insets.bottom;
   // Clamp to at least one item to prevent empty page math.
   return std::max(1, availableHeight / lineHeight);
 }
@@ -94,18 +91,11 @@ void XtcReaderChapterSelectionActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
   const auto pageWidth = renderer.getScreenWidth();
-  const auto orientation = renderer.getOrientation();
-  // Landscape orientation: reserve a horizontal gutter for button hints.
-  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
-  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  // Inverted portrait: reserve vertical space for hints at the top.
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
-  // Landscape CW places hints on the left edge; CCW keeps them on the right.
-  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
-  const int contentWidth = pageWidth - hintGutterWidth;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int contentY = hintGutterHeight;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = pageWidth - insets.left - insets.right;
+  const int contentY = insets.top;
   const int pageItems = getPageItems();
   // Manual centering to honor content gutters.
   const int titleX =
@@ -130,11 +120,8 @@ void XtcReaderChapterSelectionActivity::render(RenderLock&&) {
     renderer.drawText(UI_10_FONT_ID, contentX + 20, 60 + contentY + (i % pageItems) * 30, title, i != selectorIndex);
   }
 
-  // Skip button hints in landscape CW mode (they overlap content)
-  if (renderer.getOrientation() != GfxRenderer::LandscapeClockwise) {
-    const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-  }
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   renderer.displayBuffer();
 }

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.h
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.h
@@ -24,4 +24,6 @@ class XtcReaderChapterSelectionActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
 };

--- a/src/activities/reader/XtcReaderMenuActivity.cpp
+++ b/src/activities/reader/XtcReaderMenuActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalGPIO.h>
 #include <I18n.h>
 
+#include <algorithm>
 #include <cstdio>
 
 #include "CrossPointSettings.h"
@@ -90,15 +91,11 @@ void XtcReaderMenuActivity::loop() {
 void XtcReaderMenuActivity::render(RenderLock&&) {
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
-  const auto orientation = renderer.getOrientation();
-  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
-  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
-  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
-  const int contentWidth = pageWidth - hintGutterWidth;
-  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
-  const int contentY = hintGutterHeight;
+  // ボタンヒントが占める辺（縦持ちは下端、反転は上端、横向きは短辺側）を避ける
+  const auto insets = GUI.getButtonHintInsets(renderer);
+  const int contentX = insets.left;
+  const int contentWidth = pageWidth - insets.left - insets.right;
+  const int contentY = insets.top;
 
   // タイトル
   const std::string truncTitle =
@@ -121,10 +118,15 @@ void XtcReaderMenuActivity::render(RenderLock&&) {
   // メニュー項目
   const int startY = 75 + contentY;
   constexpr int lineHeight = 30;
+  // 画面高さに収まる行数だけ描き、選択項目を含むページを表示する（EpubReaderMenuActivity と同じ）
+  const int availableHeight = renderer.getScreenHeight() - startY - insets.bottom;
+  const int pageItems = std::max(1, availableHeight / lineHeight);
+  const int pageStart = selectedIndex / pageItems * pageItems;
+  const int pageEnd = std::min(static_cast<int>(menuItems.size()), pageStart + pageItems);
 
-  for (size_t i = 0; i < menuItems.size(); ++i) {
-    const int displayY = startY + (i * lineHeight);
-    const bool isSelected = (static_cast<int>(i) == selectedIndex);
+  for (int i = pageStart; i < pageEnd; ++i) {
+    const int displayY = startY + ((i - pageStart) * lineHeight);
+    const bool isSelected = (i == selectedIndex);
 
     if (isSelected) {
       renderer.fillRect(contentX, displayY, contentWidth - 1, lineHeight, true);

--- a/src/activities/reader/XtcReaderMenuActivity.h
+++ b/src/activities/reader/XtcReaderMenuActivity.h
@@ -18,6 +18,8 @@ class XtcReaderMenuActivity final : public Activity {
   void onEnter() override;
   void onExit() override;
   void loop() override;
+  // リーダーの向き（横向き含む）を継承する
+  bool supportsLandscape() const override { return true; }
   void render(RenderLock&&) override;
 
  private:

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <string>
 
+#include "HintOrientationScope.h"
 #include "I18n.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
@@ -138,8 +139,33 @@ void BaseTheme::drawProgressBar(const GfxRenderer& renderer, Rect rect, const si
   renderer.drawCenteredText(UI_10_FONT_ID, rect.y + rect.height + 15, percentText.c_str());
 }
 
+ButtonHintInsets BaseTheme::getButtonHintInsets(const GfxRenderer& renderer) const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const int reserved = metrics.buttonHintsHeight + metrics.verticalSpacing;
+  ButtonHintInsets insets;
+  switch (renderer.getOrientation()) {
+    case GfxRenderer::Orientation::PortraitInverted:
+      insets.top = reserved;
+      break;
+    case GfxRenderer::Orientation::LandscapeClockwise:
+      // 縦持ちの下端（ボタン側）が左に来る
+      insets.left = reserved;
+      break;
+    case GfxRenderer::Orientation::LandscapeCounterClockwise:
+      insets.right = reserved;
+      break;
+    case GfxRenderer::Orientation::Portrait:
+    default:
+      insets.bottom = reserved;
+      break;
+  }
+  return insets;
+}
+
 void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                                 const char* btn4) const {
+  // 横向きでもボタンの物理位置（縦持ちの下端）に描く
+  const HintOrientationScope orientationScope(renderer);
   const int pageHeight = renderer.getScreenHeight();
   const bool placeAtTop = renderer.getOrientation() == GfxRenderer::Orientation::PortraitInverted;
   constexpr int buttonWidth = 106;

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -25,6 +25,16 @@ struct TabInfo {
   bool selected;
 };
 
+// ボタンヒントが占める領域ぶんの余白（論理座標）。ヒントは前面ボタンの物理位置に
+// 合わせて描かれるため、向きによって上下左右のどこを空けるべきかが変わる。
+// 縦持ち: 下端（反転時は上端）。横向き: ボタンのある短辺側（CW は左、CCW は右）。
+struct ButtonHintInsets {
+  int top = 0;
+  int bottom = 0;
+  int left = 0;
+  int right = 0;
+};
+
 struct ThemeMetrics {
   int batteryWidth;
   int batteryHeight;
@@ -147,6 +157,9 @@ class BaseTheme {
                                bool showPercentage = true) const;  // Left aligned (reader mode)
   virtual void drawBatteryRight(const GfxRenderer& renderer, Rect rect,
                                 bool showPercentage = true) const;  // Right aligned (UI headers)
+  // drawButtonHints() が占める領域を、コンテンツ側が避けるための余白を返す。
+  // buttonHintsHeight + verticalSpacing ぶんを、現在の向きに応じた辺に割り当てる。
+  ButtonHintInsets getButtonHintInsets(const GfxRenderer& renderer) const;
   virtual void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                                const char* btn4) const;
   virtual void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;

--- a/src/components/themes/HintOrientationScope.h
+++ b/src/components/themes/HintOrientationScope.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <GfxRenderer.h>
+
+// ボタンヒントを描く間だけ、レンダラの向きを Portrait に固定する RAII ヘルパ。
+//
+// 前面ボタンは縦持ちでの下端（短辺側）に並んでいる。横向きで読んでいるときも
+// ボタンの物理位置は変わらないので、ヒントは Portrait 座標の下端に描けば
+// そのままボタンの真横に出る（文字は 90° 回った見え方になる。本家と同じ方式）。
+// 縦持ち（通常・反転）では向きを変えない。反転時の「上端に描く」判定は
+// 呼び出し側がそのまま行える。
+class HintOrientationScope {
+ public:
+  explicit HintOrientationScope(GfxRenderer& renderer) : renderer(renderer), original(renderer.getOrientation()) {
+    if (isLandscape(original)) {
+      renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+    }
+  }
+  ~HintOrientationScope() { renderer.setOrientation(original); }
+  HintOrientationScope(const HintOrientationScope&) = delete;
+  HintOrientationScope& operator=(const HintOrientationScope&) = delete;
+
+  static bool isLandscape(const GfxRenderer::Orientation o) {
+    return o == GfxRenderer::Orientation::LandscapeClockwise ||
+           o == GfxRenderer::Orientation::LandscapeCounterClockwise;
+  }
+
+ private:
+  GfxRenderer& renderer;
+  const GfxRenderer::Orientation original;
+};

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "../HintOrientationScope.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "components/icons/book.h"
@@ -369,6 +370,8 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
 void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                                 const char* btn4) const {
+  // 横向きでもボタンの物理位置（縦持ちの下端）に描く
+  const HintOrientationScope orientationScope(renderer);
   const int pageHeight = renderer.getScreenHeight();
   const bool placeAtTop = renderer.getOrientation() == GfxRenderer::Orientation::PortraitInverted;
   const bool roundTop = !placeAtTop;


### PR DESCRIPTION
## 概要

横向き（LandscapeCW / CCW）で読んでいるときにメニューなどを開くと縦向きに切り替わっていた挙動をやめ、リーダー配下の 6 画面（EPUB / XTC のメニューと章一覧、脚注一覧、%移動）がリーダーの向きを継承するようにします。PR #126 のときに「サブアクティビティは継承しない」と決めた 2 つの障害（ボタンヒントの位置、メニューの溢れ）を解消したうえでの方針転換です。

## 変更（2 コミット）

**1. テーマ: ボタンヒントを横向きでも前面ボタンの物理位置に描く**
- `HintOrientationScope`（新規）: `drawButtonHints()` の間だけレンダラの向きを Portrait に固定する RAII。前面ボタンは短辺側にあるので、Portrait 座標の下端に描けばボタンの真横に出る。本家 `BaseTheme::drawButtonHints` と同じ方式。Base / Lyra 両テーマに適用
- `BaseTheme::getButtonHintInsets()`（新規）: ヒントが占める辺ぶんの余白（`buttonHintsHeight + verticalSpacing`）を返す。縦持ちは下端、反転は上端、横向きは CW が左・CCW が右

**2. 画面側**
- 6 画面に `supportsLandscape() = true`
- 各画面に散らばっていたヒント用余白の計算（横向き 30px 固定・反転 50px 固定）を `GUI.getButtonHintInsets()` に置き換え、ヒントの実寸（40px + 間隔）と一致させる
- リーダーメニュー（EPUB / XTC）: 画面高さに収まる行数だけ描き、選択項目を含むページを表示する。横向きの高さ 480 では 15〜16 項目が収まらなかった。縦持ちは全項目が 1 ページに入り従来どおり
- 脚注一覧: 行数計算が見出しとヒント領域を無視していたのを修正。選択ハイライトもヒント領域に重ねない
- %移動: 中央揃えをヒント領域を除いた幅で行う
- XTC 章一覧: 横向き CW のときだけヒントを描かない回避策を削除

## 前後比較（シミュレータ X4、BIZUDGothic）

| 修正前（横向き CW でメニュー） | 修正後 |
|---|---|
| ![修正前 CW メニュー](https://github.com/user-attachments/assets/04869caa-bbe5-4d2c-b65d-e0003d6ca152) | ![修正後 CW メニュー](https://github.com/user-attachments/assets/2b325bd9-1cea-4c5c-b93c-4b0acb829650) |

修正前はヒントが縦持ち位置（論理下端）に描かれてメニューに重なり、下 2 項目が画面外に切れていた。修正後はヒントが左端（ボタン側）に並び、13 項目 + 次ページになる。

| 修正後 CW 章一覧 | 修正後 CW %移動 | 修正後 CCW メニュー |
|---|---|---|
| ![修正後 CW 章一覧](https://github.com/user-attachments/assets/fe76137c-c93b-488d-b8c7-4549675909ca) | ![修正後 CW %移動](https://github.com/user-attachments/assets/98129ce6-7269-4fc2-8a60-3e4f1bad08a5) | ![修正後 CCW メニュー](https://github.com/user-attachments/assets/bcc517a7-d101-4e4e-aa56-14b49aca2422) |

CCW ではヒントが右端に出て、上から「上・下・選択・戻る」の順で物理ボタンと一致する（`MappedInputManager::mapLabels` の CCW 入れ替えがそのまま効く）。縦持ちのメニューは変更前と同じ見え方であることも確認済み。

## 確認

- `pio run -e default` 成功、clang-format 差分なし
- シミュレータで横向き CW / CCW / 縦持ちのメニュー・章一覧・%移動を確認（`Outside range` なし）
- **X3 実機で確認済み**（SD 経由で焼いて、横向き CW / CCW のメニュー・章一覧・%移動、縦向きへの復帰）

## 備考

- ヒントの文字は横向きでは 90° 回った見え方になる（本家と同じ）
- 別件: 横向きでスクリーンショットを撮ると「保存しました」のポップアップが画面下端を 5px はみ出す（`ScreenshotUtil`、リーダー本体の既存問題）。この PR では触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)