### PR TITLE
fix: 48バイトヘッダの XTC ファイルを開けるようにする

### DIFF
--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -180,9 +180,16 @@ uint64_t XtcParser::metadataBase() {
   if (base < MIN_HEADER_SIZE || base + METADATA_SIZE > fileSize) {
     return 0;
   }
-  // ページインデックスに食い込む位置は不正。
-  // 48 バイトヘッダ形式のようにメタデータ領域自体が存在しないファイルを弾く。
-  if (m_header.pageTableOffset > base && base + METADATA_SIZE > m_header.pageTableOffset) {
+
+  // 既知のどの形式でもメタデータはページインデックスより前に置かれる。
+  // そこに収まらない位置はメタデータ領域ではないとみなし、読まない。
+  //
+  // 48 バイトヘッダ形式は metadataOffset=0 かつ pageTableOffset=48 なので、
+  // フォールバック先の 56 がインデックスの内側を指してしまう。
+  // hasMetadata=1 で出力されるファイルがあるため、ここで弾かないと
+  // インデックスのバイト列をタイトル・著者として読んでしまう。
+  // pageTableOffset=0（壊れたヘッダ）もこの条件で 0 になる。
+  if (base + METADATA_SIZE > m_header.pageTableOffset) {
     return 0;
   }
   return base;

--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -151,6 +151,19 @@ XtcError XtcParser::readHeader() {
     return XtcError::CORRUPTED_HEADER;
   }
 
+  // 48 バイトヘッダ形式（xtcjs.app など）への対応。
+  // この形式には chapterOffset/padding が無く、ページインデックスが
+  // オフセット 48 から直接始まる。上で 56 バイト読み込んでいるため、
+  // 末尾 8 バイトにはインデックス先頭のバイト列が入ってしまっている。
+  // 章情報として解釈すると誤動作するので、ここで無効化しておく。
+  if (m_header.pageTableOffset >= MIN_HEADER_SIZE && m_header.pageTableOffset < sizeof(XtcHeader)) {
+    LOG_DBG("XTC", "Compact %u-byte header detected; chapter fields discarded",
+            static_cast<unsigned>(m_header.pageTableOffset));
+    m_header.chapterOffset = 0;
+    m_header.padding = 0;
+    m_header.hasChapters = 0;
+  }
+
   LOG_DBG("XTC", "Header: magic=0x%08X (%s), ver=%u.%u, pages=%u, bitDepth=%u", m_header.magic,
           (m_header.magic == XTCH_MAGIC) ? "XTCH" : "XTC", m_header.versionMajor, m_header.versionMinor,
           m_header.pageCount, m_bitDepth);
@@ -158,13 +171,36 @@ XtcError XtcParser::readHeader() {
   return XtcError::OK;
 }
 
+uint64_t XtcParser::metadataBase() {
+  // メタデータ位置はヘッダの metadataOffset に従う。
+  // 0 の場合のみ、従来の固定配置（56 バイトヘッダの直後 = 0x38）にフォールバックする。
+  const uint64_t base = m_header.metadataOffset != 0 ? m_header.metadataOffset : sizeof(XtcHeader);
+
+  const uint64_t fileSize = m_file.size();
+  if (base < MIN_HEADER_SIZE || base + METADATA_SIZE > fileSize) {
+    return 0;
+  }
+  // ページインデックスに食い込む位置は不正。
+  // 48 バイトヘッダ形式のようにメタデータ領域自体が存在しないファイルを弾く。
+  if (m_header.pageTableOffset > base && base + METADATA_SIZE > m_header.pageTableOffset) {
+    return 0;
+  }
+  return base;
+}
+
 XtcError XtcParser::readTitle() {
-  constexpr auto titleOffset = 0x38;
-  if (!m_file.seek(titleOffset)) {
+  const uint64_t base = metadataBase();
+  if (base == 0) {
+    LOG_DBG("XTC", "No usable metadata area; skipping title");
+    m_title.clear();
+    return XtcError::OK;
+  }
+
+  if (!m_file.seek(static_cast<size_t>(base))) {
     return XtcError::READ_ERROR;
   }
 
-  char titleBuf[128] = {0};
+  char titleBuf[TITLE_SIZE] = {0};
   m_file.read(titleBuf, sizeof(titleBuf) - 1);
   m_title = titleBuf;
 
@@ -174,12 +210,17 @@ XtcError XtcParser::readTitle() {
 
 XtcError XtcParser::readAuthor() {
   // Read author as null-terminated UTF-8 string with max length 64, directly following title
-  constexpr auto authorOffset = 0xB8;
-  if (!m_file.seek(authorOffset)) {
+  const uint64_t base = metadataBase();
+  if (base == 0) {
+    m_author.clear();
+    return XtcError::OK;
+  }
+
+  if (!m_file.seek(static_cast<size_t>(base + TITLE_SIZE))) {
     return XtcError::READ_ERROR;
   }
 
-  char authorBuf[64] = {0};
+  char authorBuf[AUTHOR_SIZE] = {0};
   m_file.read(authorBuf, sizeof(authorBuf) - 1);
   m_author = authorBuf;
 
@@ -196,7 +237,7 @@ XtcError XtcParser::readFirstPageInfo() {
   // Verify the file is large enough to contain the full page table
   const uint64_t fileSize = m_file.size();
   const uint64_t pageTableSize = static_cast<uint64_t>(m_header.pageCount) * sizeof(PageTableEntry);
-  if (m_header.pageTableOffset < sizeof(XtcHeader) || m_header.pageTableOffset > fileSize ||
+  if (m_header.pageTableOffset < MIN_HEADER_SIZE || m_header.pageTableOffset > fileSize ||
       pageTableSize > fileSize - m_header.pageTableOffset) {
     LOG_DBG("XTC", "Page table exceeds file bounds");
     return XtcError::CORRUPTED_HEADER;
@@ -262,32 +303,20 @@ XtcError XtcParser::readChapters() {
     return XtcError::READ_ERROR;
   }
 
-  uint8_t hasChaptersFlag = 0;
-  if (!m_file.seek(0x0B)) {
-    return XtcError::READ_ERROR;
-  }
-  if (m_file.read(&hasChaptersFlag, sizeof(hasChaptersFlag)) != sizeof(hasChaptersFlag)) {
-    return XtcError::READ_ERROR;
-  }
-
-  if (hasChaptersFlag != 1) {
+  // 章情報の有無とオフセットは readHeader() で読み込み済みのヘッダを使う。
+  // ファイルから読み直すと、48 バイトヘッダ形式で無効化したはずの
+  // chapterOffset がページインデックスのバイト列として復活してしまう。
+  if (m_header.hasChapters != 1) {
     return XtcError::OK;
   }
 
-  uint64_t chapterOffset = 0;
-  if (!m_file.seek(0x30)) {
-    return XtcError::READ_ERROR;
-  }
-  if (m_file.read(reinterpret_cast<uint8_t*>(&chapterOffset), sizeof(chapterOffset)) != sizeof(chapterOffset)) {
-    return XtcError::READ_ERROR;
-  }
-
+  const uint64_t chapterOffset = m_header.chapterOffset;
   if (chapterOffset == 0) {
     return XtcError::OK;
   }
 
   const uint64_t fileSize = m_file.size();
-  if (chapterOffset < sizeof(XtcHeader) || chapterOffset >= fileSize || chapterOffset + 96 > fileSize) {
+  if (chapterOffset < MIN_HEADER_SIZE || chapterOffset >= fileSize || chapterOffset + 96 > fileSize) {
     return XtcError::OK;
   }
 

--- a/lib/Xtc/Xtc/XtcParser.h
+++ b/lib/Xtc/Xtc/XtcParser.h
@@ -101,6 +101,8 @@ class XtcParser {
   // Internal helper functions
   XtcError readHeader();
   XtcError readFirstPageInfo();
+  // メタデータ（タイトル + 著者）の先頭オフセット。読める領域が無ければ 0
+  uint64_t metadataBase();
   XtcError readTitle();
   XtcError readAuthor();
   XtcError readChapters();

--- a/lib/Xtc/Xtc/XtcTypes.h
+++ b/lib/Xtc/Xtc/XtcTypes.h
@@ -31,6 +31,17 @@ constexpr uint32_t XTH_MAGIC = 0x00485458;  // "XTH\0" for 2-bit page data
 constexpr uint16_t DISPLAY_WIDTH = 480;
 constexpr uint16_t DISPLAY_HEIGHT = 800;
 
+// 一部の生成ツール（xtcjs.app など）は chapterOffset/padding を持たない
+// 48 バイトのヘッダを出力し、ページインデックスをオフセット 48 から直接始める。
+// ヘッダとして受け付ける最小サイズであり、各種オフセットの下限チェックに使う。
+constexpr uint64_t MIN_HEADER_SIZE = 48;
+
+// メタデータ領域のレイアウト（title 128 + author 64 + publisher 32 + language 16 + その他 16）
+constexpr size_t TITLE_SIZE = 128;
+constexpr size_t AUTHOR_SIZE = 64;
+// パーサが実際に読むのはタイトルと著者だけなので、範囲チェックもその分だけ行う
+constexpr uint64_t METADATA_SIZE = TITLE_SIZE + AUTHOR_SIZE;
+
 // XTC file header (56 bytes)
 #pragma pack(push, 1)
 struct XtcHeader {


### PR DESCRIPTION
Closes #137

## 問題

[xtcjs.app](https://xtcjs.app) が出力する XTC は、`chapterOffset`/`padding` を持たない **48 バイト**のヘッダで、ページインデックスがオフセット 48 から直接始まる。

`readFirstPageInfo()` が `pageTableOffset >= sizeof(XtcHeader)`（= 56）を要求していたため、`48 < 56` でこれらのファイルは `CORRUPTED_HEADER` になり開けなかった。

該当箇所: `lib/Xtc/Xtc/XtcParser.cpp:199-203`

ユーザ側の回避策として [sij1mii/XTC_FIX](https://github.com/sij1mii/XTC_FIX) が公開されているが、本体側で読めるようにする。

## 対応

- オフセットの下限チェックを `MIN_HEADER_SIZE`（48）に緩和
- 48 バイト形式では、56 バイト読み込んだ末尾 8 バイトが**ページインデックスの先頭バイト列**になっているため、`chapterOffset`/`padding`/`hasChapters` を `readHeader()` で無効化する
  - 実際、これらのファイルでは `chapterOffset` にページ0のデータオフセットの下位32ビットが入り、そのままだと章情報として誤読される
- `readChapters()` はファイルから読み直さず、正規化済みのヘッダを使う（読み直すと無効化したはずの `chapterOffset` が復活してしまうため）
- タイトル/著者の位置を `0x38`/`0xB8` の固定値ではなくヘッダの `metadataOffset` に従わせ、メタデータ領域として妥当でない位置なら読み飛ばす

### レビュー指摘の反映（2コミット目）

`metadataBase()` のページインデックスとの重なり判定が片側しか見ておらず、**このPRが対象とする形式に対してデッドコードだった**。

```cpp
if (m_header.pageTableOffset > base && ...)   // 48 > 56 は偽 → 素通り
```

48 バイト形式は `pageTableOffset=48`、`metadataOffset=0` のときのフォールバック先は 56。`base < 48` は直前のチェックで既に弾かれているため、この条件は常に偽になる。`hasMetadata=1` のファイルだとインデックスのバイト列をタイトル・著者として読んでしまう。

XTC_FIX が変換後に `hasMetadata=1` を書いていることから、元ファイルで立っている個体はあると考えられる。再現ファイルで実際に踏むことを確認した。

```
修正前: Title: ??   Author: ?????????????????????
修正後: No usable metadata area; skipping title
```

「既知のどの形式でもメタデータはページインデックスより前に置かれる」という前提に寄せ、インデックス開始位置までに収まらなければメタデータ領域なしと判定するように変更。ページデータ内を指す `metadataOffset` や `pageTableOffset=0` の壊れたヘッダも同じ条件で弾ける。タイトルが空のときは `Xtc.cpp:62` でファイル名にフォールバックする。

## 検証

### 実機（X3）

- 48 バイト形式が開けること、ページ送りでページが切り替わることを確認
- 既存の XTC（`ie 2023.11.11.xtc` 637ページ、`Archived/` の各ファイル）が今までどおり開けることを確認

### ホストシミュレータ

| ケース | 結果 |
|---|---|
| 48バイト形式（metadata/chapters なし） | 修正前 `Corrupted header` → **修正後 開ける** |
| 48バイト形式（`hasMetadata=1`） | 修正前 Title/Author が文字化け → **修正後 読み飛ばし** |
| 従来の 56バイト形式（metadata + 章2件） | Title・Author・`Chapters: 2` を従来どおり読める |
| XTC_FIX の変換済みファイル | 引き続き開ける |
| 48バイト形式のページ送り | ページごとに描画が切り替わる |

### ビルドと静的解析

- `pio run -e default` 成功
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` → No defects found
- `bin/clang-format-fix` 適用済み

## 補足

SD カード上の既存 XTC は全て 56 バイト形式だったため、報告された「開けないファイル」の現物では検証できていない。再現ファイルはフォーマット仕様から生成したもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)